### PR TITLE
Go Report Card warning: "substract" is a misspelling of "subtract"

### DIFF
--- a/backtest.go
+++ b/backtest.go
@@ -69,10 +69,10 @@ func ApplyActions(prices []float64, actions []Action) []float64 {
 }
 
 // The NormalizeGains takes the given list of prices, calculates the
-// price gains, substracts it from the given list of gains.
+// price gains, subtracts it from the given list of gains.
 func NormalizeGains(prices, gains []float64) []float64 {
 	priceGains := Sum(len(prices), percentDiff(prices, 1))
-	normalized := substract(gains, priceGains)
+	normalized := subtract(gains, priceGains)
 
 	return normalized
 }

--- a/backtest.md
+++ b/backtest.md
@@ -33,7 +33,7 @@ normalized := indicator.NormalizeActions(actions)
 
 #### Normalize Gains
 
-The [NormalizeGains](https://pkg.go.dev/github.com/cinar/indicator#NormalizeGains) takes the given list of prices, calculates the price gains, substracts it from the given list of gains.
+The [NormalizeGains](https://pkg.go.dev/github.com/cinar/indicator#NormalizeGains) takes the given list of prices, calculates the price gains, subtracts it from the given list of gains.
 
 ```golang
 normalizedGains := indicator.NormalizeGains(prices, gains)

--- a/helper.go
+++ b/helper.go
@@ -90,15 +90,15 @@ func addBy(values []float64, addition float64) []float64 {
 	return result
 }
 
-// Substract values2 from values1.
-func substract(values1, values2 []float64) []float64 {
-	substract := multiplyBy(values2, float64(-1))
-	return add(values1, substract)
+// subtract values2 from values1.
+func subtract(values1, values2 []float64) []float64 {
+	subtract := multiplyBy(values2, float64(-1))
+	return add(values1, subtract)
 }
 
 // Difference between current and before values.
 func diff(values []float64, before int) []float64 {
-	return substract(values, shiftRight(before, values))
+	return subtract(values, shiftRight(before, values))
 }
 
 // Percent difference between current and before values.

--- a/helper_test.go
+++ b/helper_test.go
@@ -123,7 +123,7 @@ func TestAddBy(t *testing.T) {
 	}
 }
 
-func Testsubtract(t *testing.T) {
+func TestSubtract(t *testing.T) {
 	values1 := []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
 	values2 := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -123,11 +123,11 @@ func TestAddBy(t *testing.T) {
 	}
 }
 
-func TestSubstract(t *testing.T) {
+func Testsubtract(t *testing.T) {
 	values1 := []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
 	values2 := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-	result := substract(values1, values2)
+	result := subtract(values1, values2)
 	checkSameSize(result, values1)
 
 	for i := 0; i < len(result); i++ {

--- a/momentum_indicators.go
+++ b/momentum_indicators.go
@@ -15,7 +15,7 @@ func AwesomeOscillator(low, high []float64) []float64 {
 	medianPrice := divideBy(add(low, high), float64(2))
 	sma5 := Sma(5, medianPrice)
 	sma34 := Sma(34, medianPrice)
-	ao := substract(sma5, sma34)
+	ao := subtract(sma5, sma34)
 
 	return ao
 }
@@ -31,7 +31,7 @@ func AwesomeOscillator(low, high []float64) []float64 {
 // Returns co, ad.
 func ChaikinOscillator(fastPeriod, slowPeriod int, low, high, closing []float64, volume []int64) ([]float64, []float64) {
 	ad := AccumulationDistribution(high, low, closing, volume)
-	co := substract(Ema(fastPeriod, ad), Ema(slowPeriod, ad))
+	co := subtract(Ema(fastPeriod, ad), Ema(slowPeriod, ad))
 
 	return co, ad
 }
@@ -130,7 +130,7 @@ func StochasticOscillator(high, low, closing []float64) ([]float64, []float64) {
 	highestHigh14 := Max(14, high)
 	lowestLow14 := Min(14, low)
 
-	k := multiplyBy(divide(substract(closing, lowestLow14), substract(highestHigh14, lowestLow14)), float64(100))
+	k := multiplyBy(divide(subtract(closing, lowestLow14), subtract(highestHigh14, lowestLow14)), float64(100))
 	d := Sma(3, k)
 
 	return k, d

--- a/trend_indicators.go
+++ b/trend_indicators.go
@@ -37,7 +37,7 @@ const (
 func AbsolutePriceOscillator(fastPeriod, slowPeriod int, values []float64) []float64 {
 	fast := Ema(fastPeriod, values)
 	slow := Ema(slowPeriod, values)
-	apo := substract(fast, slow)
+	apo := subtract(fast, slow)
 
 	return apo
 }
@@ -86,7 +86,7 @@ func Aroon(high, low []float64) ([]float64, []float64) {
 //
 // Returns bop.
 func BalanceOfPower(opening, high, low, closing []float64) []float64 {
-	bop := divide(substract(closing, opening), substract(high, low))
+	bop := divide(subtract(closing, opening), subtract(high, low))
 	return bop
 }
 
@@ -104,7 +104,7 @@ func ChandeForecastOscillator(closing []float64) []float64 {
 	x := generateNumbers(0, float64(len(closing)), 1)
 	r := LinearRegressionUsingLeastSquare(x, closing)
 
-	cfo := multiplyBy(divide(substract(closing, r), closing), 100)
+	cfo := multiplyBy(divide(subtract(closing, r), closing), 100)
 
 	return cfo
 }
@@ -121,8 +121,8 @@ func ChandeForecastOscillator(closing []float64) []float64 {
 func CommunityChannelIndex(period int, high, low, closing []float64) []float64 {
 	tp, _ := TypicalPrice(low, high, closing)
 	ma := Sma(period, tp)
-	md := Sma(period, abs(substract(tp, ma)))
-	cci := divide(substract(tp, ma), multiplyBy(md, 0.015))
+	md := Sma(period, abs(subtract(tp, ma)))
+	cci := divide(subtract(tp, ma), multiplyBy(md, 0.015))
 	cci[0] = 0
 
 	return cci
@@ -142,7 +142,7 @@ func Dema(period int, values []float64) []float64 {
 	ema1 := Ema(period, values)
 	ema2 := Ema(period, ema1)
 
-	dema := substract(multiplyBy(ema1, 2), ema2)
+	dema := subtract(multiplyBy(ema1, 2), ema2)
 
 	return dema
 }
@@ -173,7 +173,7 @@ func Ema(period int, values []float64) []float64 {
 func Macd(closing []float64) ([]float64, []float64) {
 	ema12 := Ema(12, closing)
 	ema26 := Ema(26, closing)
-	macd := substract(ema12, ema26)
+	macd := subtract(ema12, ema26)
 	signal := Ema(9, macd)
 
 	return macd, signal
@@ -189,7 +189,7 @@ func Macd(closing []float64) ([]float64, []float64) {
 //
 // Returns mi.
 func MassIndex(high, low []float64) []float64 {
-	ema1 := Ema(9, substract(high, low))
+	ema1 := Ema(9, subtract(high, low))
 	ema2 := Ema(9, ema1)
 	ratio := divide(ema1, ema2)
 	mi := Sum(25, ratio)
@@ -214,7 +214,7 @@ func MovingChandeForecastOscillator(period int, closing []float64) []float64 {
 	x := generateNumbers(0, float64(len(closing)), 1)
 	r := MovingLinearRegressionUsingLeastSquare(period, x, closing)
 
-	cfo := multiplyBy(divide(substract(closing, r), closing), 100)
+	cfo := multiplyBy(divide(subtract(closing, r), closing), 100)
 
 	return cfo
 }
@@ -348,7 +348,7 @@ func ParabolicSar(high, low, closing []float64) ([]float64, []Trend) {
 //
 // Returns qs.
 func Qstick(period int, opening, closing []float64) []float64 {
-	qs := Sma(period, substract(closing, opening))
+	qs := Sma(period, subtract(closing, opening))
 	return qs
 }
 
@@ -373,11 +373,11 @@ func Kdj(rPeriod, kPeriod, dPeriod int, high, low, closing []float64) ([]float64
 	highest := Max(rPeriod, high)
 	lowest := Min(rPeriod, low)
 
-	rsv := multiplyBy(divide(substract(closing, lowest), substract(highest, lowest)), 100)
+	rsv := multiplyBy(divide(subtract(closing, lowest), subtract(highest, lowest)), 100)
 
 	k := Sma(kPeriod, rsv)
 	d := Sma(dPeriod, k)
-	j := substract(multiplyBy(k, 3), multiplyBy(d, 2))
+	j := subtract(multiplyBy(k, 3), multiplyBy(d, 2))
 
 	return k, d, j
 }
@@ -490,7 +490,7 @@ func Tema(period int, values []float64) []float64 {
 	ema2 := Ema(period, ema1)
 	ema3 := Ema(period, ema2)
 
-	tema := add(substract(multiplyBy(ema1, 3), multiplyBy(ema2, 3)), ema3)
+	tema := add(subtract(multiplyBy(ema1, 3), multiplyBy(ema2, 3)), ema3)
 
 	return tema
 }
@@ -535,7 +535,7 @@ func Trix(period int, values []float64) []float64 {
 	ema2 := Ema(period, ema1)
 	ema3 := Ema(period, ema2)
 	previous := shiftRightAndFillBy(1, ema3[0], ema3)
-	trix := divide(substract(ema3, previous), previous)
+	trix := divide(subtract(ema3, previous), previous)
 
 	return trix
 }

--- a/volatility_indicators.go
+++ b/volatility_indicators.go
@@ -20,7 +20,7 @@ import (
 func AccelerationBands(high, low, closing []float64) ([]float64, []float64, []float64) {
 	checkSameSize(high, low, closing)
 
-	k := divide(substract(high, low), add(high, low))
+	k := divide(subtract(high, low), add(high, low))
 
 	upperBand := Sma(20, multiply(high, addBy(multiplyBy(k, 4), 1)))
 	middleBand := Sma(20, closing)
@@ -86,7 +86,7 @@ func BollingerBands(closing []float64) ([]float64, []float64, []float64) {
 
 	middleBand := Sma(20, closing)
 	upperBand := add(middleBand, std2)
-	lowerBand := substract(middleBand, std2)
+	lowerBand := subtract(middleBand, std2)
 
 	return middleBand, upperBand, lowerBand
 }
@@ -159,7 +159,7 @@ func ProjectionOscillator(period, smooth int, high, low, closing []float64) ([]f
 	pu := Max(period, vHigh)
 	pl := Min(period, vLow)
 
-	po := divide(multiplyBy(substract(closing, pl), 100), substract(pu, pl))
+	po := divide(multiplyBy(subtract(closing, pl), 100), subtract(pu, pl))
 	spo := Ema(smooth, po)
 
 	return po, spo
@@ -177,7 +177,7 @@ func ProjectionOscillator(period, smooth int, high, low, closing []float64) ([]f
 // Returns ui.
 func UlcerIndex(period int, closing []float64) []float64 {
 	highClosing := Max(period, closing)
-	percentageDrawdown := multiplyBy(divide(substract(closing, highClosing), highClosing), 100)
+	percentageDrawdown := multiplyBy(divide(subtract(closing, highClosing), highClosing), 100)
 	squaredAverage := Sma(period, multiply(percentageDrawdown, percentageDrawdown))
 	ui := sqrt(squaredAverage)
 
@@ -224,7 +224,7 @@ func KeltnerChannel(period int, high, low, closing []float64) ([]float64, []floa
 
 	middleLine := Ema(period, closing)
 	upperBand := add(middleLine, atr2)
-	lowerBand := substract(middleLine, atr2)
+	lowerBand := subtract(middleLine, atr2)
 
 	return upperBand, middleLine, lowerBand
 }

--- a/volume_indicators.go
+++ b/volume_indicators.go
@@ -123,7 +123,7 @@ func DefaultForceIndex(closing []float64, volume []int64) []float64 {
 // Returns ease of movement values.
 func EaseOfMovement(period int, high, low []float64, volume []int64) []float64 {
 	distanceMoved := diff(divideBy(add(high, low), 2), 1)
-	boxRatio := divide(divideBy(asFloat64(volume), float64(100000000)), substract(high, low))
+	boxRatio := divide(divideBy(asFloat64(volume), float64(100000000)), subtract(high, low))
 	emv := Sma(period, divide(distanceMoved, boxRatio))
 	return emv
 }
@@ -141,7 +141,7 @@ func DefaultEaseOfMovement(high, low []float64, volume []int64) []float64 {
 // Returns volume price trend values.
 func VolumePriceTrend(closing []float64, volume []int64) []float64 {
 	previousClosing := shiftRightAndFillBy(1, closing[0], closing)
-	vpt := multiply(asFloat64(volume), divide(substract(closing, previousClosing), previousClosing))
+	vpt := multiply(asFloat64(volume), divide(subtract(closing, previousClosing), previousClosing))
 	return Sum(len(vpt), vpt)
 }
 
@@ -202,8 +202,8 @@ func NegativeVolumeIndex(closing []float64, volume []int64) []float64 {
 //
 func ChaikinMoneyFlow(high, low, closing []float64, volume []int64) []float64 {
 	moneyFlowMultiplier := divide(
-		substract(substract(closing, low), substract(high, closing)),
-		substract(high, low))
+		subtract(subtract(closing, low), subtract(high, closing)),
+		subtract(high, low))
 
 	moneyFlowVolume := multiply(moneyFlowMultiplier, asFloat64(volume))
 


### PR DESCRIPTION
# Describe Request

Go Report Card warning: "substract" is a misspelling of "subtract" (misspell)

Fixed #96 

# Change Type

Bug fix.
