### PR TITLE
fix: added fix for sma calculation in trend_indicator.go file

### DIFF
--- a/trend_indicators.go
+++ b/trend_indicators.go
@@ -19,7 +19,6 @@ const (
 	Rising  Trend = 1
 )
 
-
 // The AbsolutePriceOscillator function calculates a technical indicator that is used
 // to follow trends. APO crossing above zero indicates bullish, while crossing below
 // zero indicates bearish. Positive value is upward trend, while negative value is
@@ -336,14 +335,14 @@ func ParabolicSar(high, low, closing []float64, psarAfStep, psarAfMax float64) (
 	}
 
 	return psar, trend
-} 
+}
 
 // DefaultParabolicSar function calculates the Parabolic SAR using a psarAfStep
 // of 0.02, and psarAfMax of 0.20.
 //
 // Returns psar, trend
 func DefaultParabolicSar(high, low, closing []float64) ([]float64, []Trend) {
-    return ParabolicSar(high, low, closing, 0.02, 0.20)
+	return ParabolicSar(high, low, closing, 0.02, 0.20)
 }
 
 // The Qstick function calculates the ratio of recent up and down bars.
@@ -423,22 +422,22 @@ func Rma(period int, values []float64) []float64 {
 
 // Simple Moving Average (SMA).
 func Sma(period int, values []float64) []float64 {
-	result := make([]float64, len(values))
-	sum := float64(0)
-
-	for i, value := range values {
-		count := i + 1
-		sum += value
-
-		if i >= period {
-			sum -= values[i-period]
-			count = period
-		}
-
-		result[i] = sum / float64(count)
+	if len(values) < period {
+		return nil
 	}
 
-	return result
+	smaValues := make([]float64, len(values))
+
+	// Calculate the SMA values using a sliding window approach
+	for i := period - 1; i < len(values); i++ {
+		var sum float64
+		for j := 0; j < period; j++ {
+			sum += values[i-j]
+		}
+		smaValues[i] = sum / float64(period)
+	}
+
+	return smaValues
 }
 
 // Since last values change.

--- a/trend_indicators_test.go
+++ b/trend_indicators_test.go
@@ -6,6 +6,7 @@
 package indicator
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -214,10 +215,11 @@ func TestRma(t *testing.T) {
 
 func TestSma(t *testing.T) {
 	values := []float64{2, 4, 6, 8, 10}
-	expected := []float64{2, 3, 5, 7, 9}
+	expected := []float64{0, 3, 5, 7, 9}
 	period := 2
 
 	actual := Sma(period, values)
+	fmt.Print(actual)
 	testEquals(t, actual, expected)
 }
 


### PR DESCRIPTION
# Describe Request

This pull request addresses issue #128.

I have made changes to the SMA (Simple Moving Average) calculation logic to improve its accuracy. The issue was related to incorrect initial values in the SMA calculation for indices less than given input period, and this pull request fixes it.

# Change Type

Change Type: Bug Fix
