### PR TITLE
Go Report Card - helper/divide.go - Line 17: warning: "divison" is a misspelling of "division" (misspell) 

### DIFF
--- a/helper/README.md
+++ b/helper/README.md
@@ -359,7 +359,7 @@ Example:
 ac := helper.SliceToChan([]int{2, 4, 6, 8, 10})
 bc := helper.SliceToChan([]int{2, 1, 3, 2, 5})
 
-divison := helper.Divide(ac, bc)
+division := helper.Divide(ac, bc)
 
 fmt.Println(helper.ChanToSlice(division)) // [1, 4, 2, 4, 2]
 ```

--- a/helper/divide.go
+++ b/helper/divide.go
@@ -14,7 +14,7 @@ package helper
 //	ac := helper.SliceToChan([]int{2, 4, 6, 8, 10})
 //	bc := helper.SliceToChan([]int{2, 1, 3, 2, 5})
 //
-//	divison := helper.Divide(ac, bc)
+//	division := helper.Divide(ac, bc)
 //
 //	fmt.Println(helper.ChanToSlice(division)) // [1, 4, 2, 4, 2]
 func Divide[T Number](ac, bc <-chan T) <-chan T {


### PR DESCRIPTION
# Describe Request

Go Report Card - helper/divide.go - Line 17: warning: "divison" is a misspelling of "division" (misspell) 

Fixed #142 

# Change Type

Bug fix.
