### PR TITLE
Use Go 1.22  in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:0-1.20-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
# Describe Request

This PR updates Go version in devcontainer.json.  Fix https://github.com/cinar/indicator/issues/161


# Change Type

N/A


I have read the CLA Document and I hereby sign the CLA
