### PR TITLE
Add .gomarkdoc.yml and update docs

### DIFF
--- a/.gomarkdoc.yml
+++ b/.gomarkdoc.yml
@@ -1,0 +1,4 @@
+excludeDirs: "./cmd/..."
+output: "{{.Dir}}/README.md"
+repository:
+  url: https://github.com/cinar/indicator

--- a/helper/README.md
+++ b/helper/README.md
@@ -124,6 +124,15 @@ const (
 )
 ```
 
+<a name="DefaultReportDateFormat"></a>
+
+```go
+const (
+    // DefaultReportDateFormat is the default date format used in the report.
+    DefaultReportDateFormat = "2006-01-02"
+)
+```
+
 <a name="Abs"></a>
 ## func [Abs](<https://github.com/cinar/indicator/blob/master/helper/abs.go#L15>)
 
@@ -1041,7 +1050,7 @@ type Number interface {
 ```
 
 <a name="Report"></a>
-## type [Report](<https://github.com/cinar/indicator/blob/master/helper/report.go#L53-L55>)
+## type [Report](<https://github.com/cinar/indicator/blob/master/helper/report.go#L48-L54>)
 
 Report generates an HTML file containing an interactive chart that visually represents the provided data and annotations.
 
@@ -1049,12 +1058,16 @@ The generated HTML file can be opened in a web browser to explore the data visua
 
 ```go
 type Report struct {
-    // contains filtered or unexported fields
+    Title      string
+    Date       <-chan time.Time
+    Columns    []ReportColumn
+    Views      [][]int
+    DateFormat string
 }
 ```
 
 <a name="NewReport"></a>
-### func [NewReport](<https://github.com/cinar/indicator/blob/master/helper/report.go#L60>)
+### func [NewReport](<https://github.com/cinar/indicator/blob/master/helper/report.go#L59>)
 
 ```go
 func NewReport(title string, date <-chan time.Time) *Report
@@ -1063,7 +1076,7 @@ func NewReport(title string, date <-chan time.Time) *Report
 NewReport takes a channel of time as the time axis and returns a new instance of the Report struct. This instance can later be used to add data and annotations and subsequently generate a report.
 
 <a name="Report.AddChart"></a>
-### func \(\*Report\) [AddChart](<https://github.com/cinar/indicator/blob/master/helper/report.go#L76>)
+### func \(\*Report\) [AddChart](<https://github.com/cinar/indicator/blob/master/helper/report.go#L74>)
 
 ```go
 func (r *Report) AddChart() int
@@ -1072,7 +1085,7 @@ func (r *Report) AddChart() int
 AddChart adds a new chart to the report and returns its unique identifier. This identifier can be used later to refer to the chart and add columns to it.
 
 <a name="Report.AddColumn"></a>
-### func \(\*Report\) [AddColumn](<https://github.com/cinar/indicator/blob/master/helper/report.go#L83>)
+### func \(\*Report\) [AddColumn](<https://github.com/cinar/indicator/blob/master/helper/report.go#L81>)
 
 ```go
 func (r *Report) AddColumn(column ReportColumn, charts ...int)
@@ -1081,7 +1094,7 @@ func (r *Report) AddColumn(column ReportColumn, charts ...int)
 AddColumn adds a new data column to the specified charts. If no chart is specified, it will be added to the main chart.
 
 <a name="Report.WriteToFile"></a>
-### func \(\*Report\) [WriteToFile](<https://github.com/cinar/indicator/blob/master/helper/report.go#L111>)
+### func \(\*Report\) [WriteToFile](<https://github.com/cinar/indicator/blob/master/helper/report.go#L109>)
 
 ```go
 func (r *Report) WriteToFile(fileName string) error
@@ -1090,7 +1103,7 @@ func (r *Report) WriteToFile(fileName string) error
 WriteToFile writes the generated report content to a file with the specified name. This allows users to conveniently save the report for later viewing or analysis.
 
 <a name="Report.WriteToWriter"></a>
-### func \(\*Report\) [WriteToWriter](<https://github.com/cinar/indicator/blob/master/helper/report.go#L99>)
+### func \(\*Report\) [WriteToWriter](<https://github.com/cinar/indicator/blob/master/helper/report.go#L97>)
 
 ```go
 func (r *Report) WriteToWriter(writer io.Writer) error
@@ -1099,7 +1112,7 @@ func (r *Report) WriteToWriter(writer io.Writer) error
 WriteToWriter writes the report content to the provided io.Writer. This allows the report to be sent to various destinations, such as a file, a network socket, or even the standard output.
 
 <a name="ReportColumn"></a>
-## type [ReportColumn](<https://github.com/cinar/indicator/blob/master/helper/report.go#L23-L35>)
+## type [ReportColumn](<https://github.com/cinar/indicator/blob/master/helper/report.go#L28-L40>)
 
 ReportColumn defines the interface that all report data columns must implement. This interface ensures that different types of data columns can be used consistently within the report generation process.
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -31,12 +31,7 @@ gosec ./...
 
 revive -config=revive.toml ./...
 staticcheck ./...
-
-for package in "${PACKAGES[@]}";
-do
-    echo Package "$package"
-    gomarkdoc --output "$package"/README.md ./"$package"
-done
+gomarkdoc ./...
 
 markdownfmt -w README.md
 

--- a/strategy/README.md
+++ b/strategy/README.md
@@ -250,7 +250,7 @@ func (a *AndStrategy) Report(c <-chan *asset.Snapshot) *helper.Report
 Report processes the provided asset snapshots and generates a report annotated with the recommended actions.
 
 <a name="Backtest"></a>
-## type [Backtest](<https://github.com/cinar/indicator/blob/master/strategy/backtest.go#L44-L65>)
+## type [Backtest](<https://github.com/cinar/indicator/blob/master/strategy/backtest.go#L44-L68>)
 
 Backtest function rigorously evaluates the potential performance of the specified strategies applied to a defined set of assets. It generates comprehensive visual representations for each strategy\-asset pairing.
 
@@ -271,12 +271,15 @@ type Backtest struct {
 
     // WriteStrategyReports indicates whether the individual strategy reports should be generated.
     WriteStrategyReports bool
+
+    // DateFormat is the date format that is used in the reports.
+    DateFormat string
     // contains filtered or unexported fields
 }
 ```
 
 <a name="NewBacktest"></a>
-### func [NewBacktest](<https://github.com/cinar/indicator/blob/master/strategy/backtest.go#L89>)
+### func [NewBacktest](<https://github.com/cinar/indicator/blob/master/strategy/backtest.go#L92>)
 
 ```go
 func NewBacktest(repository asset.Repository, outputDir string) *Backtest
@@ -285,7 +288,7 @@ func NewBacktest(repository asset.Repository, outputDir string) *Backtest
 NewBacktest function initializes a new backtest instance.
 
 <a name="Backtest.Run"></a>
-### func \(\*Backtest\) [Run](<https://github.com/cinar/indicator/blob/master/strategy/backtest.go#L105>)
+### func \(\*Backtest\) [Run](<https://github.com/cinar/indicator/blob/master/strategy/backtest.go#L109>)
 
 ```go
 func (b *Backtest) Run() error

--- a/trend/README.md
+++ b/trend/README.md
@@ -682,7 +682,7 @@ func (h *Hma[T]) String() string
 String is the string representation of the HMA.
 
 <a name="Kama"></a>
-## type [Kama](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L39-L48>)
+## type [Kama](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L38-L47>)
 
 Kama represents the parameters for calculating the Kaufman's Adaptive Moving Average \(KAMA\). It is a type of moving average that adapts to market noise or volatility. It tracks prices closely during periods of small price swings and low noise.
 
@@ -715,7 +715,7 @@ type Kama[T helper.Number] struct {
 ```
 
 <a name="NewKama"></a>
-### func [NewKama](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L51>)
+### func [NewKama](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L50>)
 
 ```go
 func NewKama[T helper.Number]() *Kama[T]
@@ -724,7 +724,7 @@ func NewKama[T helper.Number]() *Kama[T]
 NewKama function initializes a new KAMA instance with the default parameters.
 
 <a name="NewKamaWith"></a>
-### func [NewKamaWith](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L60>)
+### func [NewKamaWith](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L59>)
 
 ```go
 func NewKamaWith[T helper.Number](erPeriod, fastScPeriod, slowScPeriod int) *Kama[T]
@@ -733,7 +733,7 @@ func NewKamaWith[T helper.Number](erPeriod, fastScPeriod, slowScPeriod int) *Kam
 NewKamaWith function initializes a new KAMA instance with the given parameters.
 
 <a name="Kama[T].Compute"></a>
-### func \(\*Kama\[T\]\) [Compute](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L69>)
+### func \(\*Kama\[T\]\) [Compute](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L68>)
 
 ```go
 func (k *Kama[T]) Compute(closings <-chan T) <-chan T
@@ -742,7 +742,7 @@ func (k *Kama[T]) Compute(closings <-chan T) <-chan T
 Compute function takes a channel of numbers and computes the KAMA over the specified period.
 
 <a name="Kama[T].IdlePeriod"></a>
-### func \(\*Kama\[T\]\) [IdlePeriod](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L138>)
+### func \(\*Kama\[T\]\) [IdlePeriod](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L134>)
 
 ```go
 func (k *Kama[T]) IdlePeriod() int
@@ -751,7 +751,7 @@ func (k *Kama[T]) IdlePeriod() int
 IdlePeriod is the initial period that KAMA yield any results.
 
 <a name="Kama[T].String"></a>
-### func \(\*Kama\[T\]\) [String](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L143>)
+### func \(\*Kama\[T\]\) [String](<https://github.com/cinar/indicator/blob/master/trend/kama.go#L139>)
 
 ```go
 func (k *Kama[T]) String() string


### PR DESCRIPTION
# Describe Request

This PR introduces `.gomarkdoc.yml` which includes default configuration of gomarkdoc.
This way, we can reuse the same configuration across multiple invocations such as `pre-commit.sh` and github workflow.
Also, docs are updated by executing pre-commit.sh.

Fixed # partially https://github.com/cinar/indicator/issues/172

# Change Type

Docs.