### PR TITLE
Add a workflow to check doc update

### DIFF
--- a/.github/workflows/gomarkdoc.yml
+++ b/.github/workflows/gomarkdoc.yml
@@ -1,0 +1,30 @@
+name: Doc update check
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  gomarkdoc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+         go-version: '1.22'
+         cache-dependency-path: '**/go.sum'
+
+    - name: Setup gomarkdoc
+      run: go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
+
+    - name: Run gomarkdoc
+      run: |
+        diff=$(gomarkdoc ./... -c 2>&1)
+        if [ -n '$diff' ]; then
+          echo 'Docs are not updated. Please update docs with pre-commit.sh'
+          echo '$diff'
+          exit 1
+        fi

--- a/.gomarkdoc.yml
+++ b/.gomarkdoc.yml
@@ -2,3 +2,5 @@ excludeDirs: "./cmd/..."
 output: "{{.Dir}}/README.md"
 repository:
   url: https://github.com/cinar/indicator
+  defaultBranch: master
+  path: /


### PR DESCRIPTION
# Describe Request

This PR introduces a workflow to check doc is updated in PR.
If the implementation is updated but the documentation is not, this workflow will fail.

Fixed # [172](https://github.com/cinar/indicator/issues/172)

# Change Type

Doc, Github workflow
