### PR TITLE
Using %q to quote a string in fmt.Sprintf format specifiers.

### DIFF
--- a/helper/annotation_report_column.go
+++ b/helper/annotation_report_column.go
@@ -39,7 +39,7 @@ func (c *annotationReportColumn) Value() string {
 	value := <-c.values
 
 	if value != "" {
-		return fmt.Sprintf("\"%s\"", value)
+		return fmt.Sprintf("%q", value)
 	}
 
 	return "null"


### PR DESCRIPTION
# Describe Request

Using %q to quote a string in fmt.Sprintf format specifiers.

Fixed #184 

# Change Type

Improve code.