### PR TITLE
Unused parameters are removed following golangci-lint revive errors.

### DIFF
--- a/asset/sync_test.go
+++ b/asset/sync_test.go
@@ -130,7 +130,7 @@ func TestSyncFailingTargetAssets(t *testing.T) {
 
 func TestSyncFailingTargetAppend(t *testing.T) {
 	source := &MockRepository{
-		GetSinceFunc: func(s string, t time.Time) (<-chan *asset.Snapshot, error) {
+		GetSinceFunc: func(_ string, _ time.Time) (<-chan *asset.Snapshot, error) {
 			return helper.SliceToChan([]*asset.Snapshot{}), nil
 		},
 	}
@@ -140,11 +140,11 @@ func TestSyncFailingTargetAppend(t *testing.T) {
 			return []string{"A"}, nil
 		},
 
-		LastDateFunc: func(s string) (time.Time, error) {
+		LastDateFunc: func(_ string) (time.Time, error) {
 			return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), nil
 		},
 
-		AppendFunc: func(s string, c <-chan *asset.Snapshot) error {
+		AppendFunc: func(_ string, _ <-chan *asset.Snapshot) error {
 			return errors.New("append error")
 		},
 	}

--- a/asset/tiingo_repository_test.go
+++ b/asset/tiingo_repository_test.go
@@ -38,7 +38,7 @@ func TestTiingoRepositoryGet(t *testing.T) {
 		},
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		body, err := json.Marshal(data)
 		if err != nil {
 			t.Fatal(err)
@@ -79,7 +79,7 @@ func TestTiingoRepositoryGetNotReachable(t *testing.T) {
 func TestTiingoRepositoryGetInvalid(t *testing.T) {
 	response := ""
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, response)
 	}))
 
@@ -123,7 +123,7 @@ func TestTiingoRepositoryLastDate(t *testing.T) {
 		Description:  "D",
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		body, err := json.Marshal(meta)
 		if err != nil {
 			t.Fatal(err)
@@ -149,7 +149,7 @@ func TestTiingoRepositoryLastDate(t *testing.T) {
 }
 
 func TestTiingoRepositoryLastDateInvalid(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 	}))
 
 	repository := asset.NewTiingoRepository("1234")

--- a/strategy/trend/README.md
+++ b/strategy/trend/README.md
@@ -509,7 +509,7 @@ Report processes the provided asset snapshots and generates a report annotated w
 <a name="KamaStrategy"></a>
 ## type [KamaStrategy](<https://github.com/cinar/indicator/blob/master/strategy/trend/kama_strategy.go#L16-L19>)
 
-KamaStrategy represents the configuration parameters for calculating the KAMA strategy. A closing price crossing above the KAMA suggests a bullish trend, while crossing below the KAMA indicats a bearish trend.
+KamaStrategy represents the configuration parameters for calculating the KAMA strategy. A closing price crossing above the KAMA suggests a bullish trend, while crossing below the KAMA indicates a bearish trend.
 
 ```go
 type KamaStrategy struct {


### PR DESCRIPTION
# Describe Request

Unused parameters are removed following golangci-lint revive errors.

# Change Type

Code maintenance.

