### PR TITLE
Fix incorrect variables n `backtest.NewReport`

### DIFF
--- a/cmd/indicator-backtest/main.go
+++ b/cmd/indicator-backtest/main.go
@@ -54,7 +54,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	report, err := backtest.NewReport(repositoryName, repositoryConfig)
+	report, err := backtest.NewReport(reportName, reportConfig)
 	if err != nil {
 		logger.Error("Unable to initialize report.", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
The variables passed to `backtest.NewReport` are for repository
configuration settings causing the script to fail.

This correctly sets `reportName` and `reportConfig`.
