### PR TITLE
Rename Volume Weighted Price Strategy to Weighted Price Strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The following list of strategies are currently supported by this package:
 -	[Force Index Strategy](strategy/volume/README.md#type-forceindexstrategy)
 -	[Money Flow Index Strategy](strategy/volume/README.md#type-moneyflowindexstrategy)
 -	[Negative Volume Index Strategy](strategy/volume/README.md#type-negativevolumeindexstrategy)
--	[Volume Weighted Average Price Strategy](strategy/volume/README.md#type-volumeweightedaveragepricestrategy)
+-	[Weighted Average Price Strategy](strategy/volume/README.md#type-weightedaveragepricestrategy)
 
 ### 🧪 Compound Strategies
 

--- a/strategy/volume/README.md
+++ b/strategy/volume/README.md
@@ -393,12 +393,12 @@ Report processes the provided asset snapshots and generates a report annotated w
 <a name="WeightedAveragePriceStrategy"></a>
 ## type [WeightedAveragePriceStrategy](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L19-L22>)
 
-WeightedAveragePriceStrategy represents the configuration parameters for calculating the Volume Weighted Average Price strategy. Recommends a Buy action when the closing crosses below the VWAP, recommends a Sell action when the closing crosses above the VWAP, and recommends a Hold action otherwise.
+WeightedAveragePriceStrategy represents the configuration parameters for calculating the Weighted Average Price strategy. Recommends a Buy action when the closing crosses below the VWAP, recommends a Sell action when the closing crosses above the VWAP, and recommends a Hold action otherwise.
 
 ```go
 type WeightedAveragePriceStrategy struct {
-    // VolumeWeightedAveragePrice is the Volume Weighted Average Price indicator instance.
-    VolumeWeightedAveragePrice *volume.Vwap[float64]
+    // WeightedAveragePrice is the Weighted Average Price indicator instance.
+    WeightedAveragePrice *volume.Vwap[float64]
 }
 ```
 
@@ -409,7 +409,7 @@ type WeightedAveragePriceStrategy struct {
 func NewWeightedAveragePriceStrategy() *WeightedAveragePriceStrategy
 ```
 
-NewWeightedAveragePriceStrategy function initializes a new Volume Weighted Average Price strategy instance with the default parameters.
+NewWeightedAveragePriceStrategy function initializes a new Weighted Average Price strategy instance with the default parameters.
 
 <a name="NewWeightedAveragePriceStrategyWith"></a>
 ### func [NewWeightedAveragePriceStrategyWith](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L34>)
@@ -418,7 +418,7 @@ NewWeightedAveragePriceStrategy function initializes a new Volume Weighted Avera
 func NewWeightedAveragePriceStrategyWith(period int) *WeightedAveragePriceStrategy
 ```
 
-NewWeightedAveragePriceStrategyWith function initializes a new Volume Weighted Average Price strategy instance with the given parameters.
+NewWeightedAveragePriceStrategyWith function initializes a new Weighted Average Price strategy instance with the given parameters.
 
 <a name="WeightedAveragePriceStrategy.Compute"></a>
 ### func \(\*WeightedAveragePriceStrategy\) [Compute](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L46>)

--- a/strategy/volume/README.md
+++ b/strategy/volume/README.md
@@ -56,12 +56,12 @@ The information provided on this project is strictly for informational purposes 
   - [func \(n \*NegativeVolumeIndexStrategy\) Compute\(snapshots \<\-chan \*asset.Snapshot\) \<\-chan strategy.Action](<#NegativeVolumeIndexStrategy.Compute>)
   - [func \(n \*NegativeVolumeIndexStrategy\) Name\(\) string](<#NegativeVolumeIndexStrategy.Name>)
   - [func \(n \*NegativeVolumeIndexStrategy\) Report\(c \<\-chan \*asset.Snapshot\) \*helper.Report](<#NegativeVolumeIndexStrategy.Report>)
-- [type VolumeWeightedAveragePriceStrategy](<#VolumeWeightedAveragePriceStrategy>)
-  - [func NewVolumeWeightedAveragePriceStrategy\(\) \*VolumeWeightedAveragePriceStrategy](<#NewVolumeWeightedAveragePriceStrategy>)
-  - [func NewVolumeWeightedAveragePriceStrategyWith\(period int\) \*VolumeWeightedAveragePriceStrategy](<#NewVolumeWeightedAveragePriceStrategyWith>)
-  - [func \(v \*VolumeWeightedAveragePriceStrategy\) Compute\(snapshots \<\-chan \*asset.Snapshot\) \<\-chan strategy.Action](<#VolumeWeightedAveragePriceStrategy.Compute>)
-  - [func \(v \*VolumeWeightedAveragePriceStrategy\) Name\(\) string](<#VolumeWeightedAveragePriceStrategy.Name>)
-  - [func \(v \*VolumeWeightedAveragePriceStrategy\) Report\(c \<\-chan \*asset.Snapshot\) \*helper.Report](<#VolumeWeightedAveragePriceStrategy.Report>)
+- [type WeightedAveragePriceStrategy](<#WeightedAveragePriceStrategy>)
+  - [func NewWeightedAveragePriceStrategy\(\) \*WeightedAveragePriceStrategy](<#NewWeightedAveragePriceStrategy>)
+  - [func NewWeightedAveragePriceStrategyWith\(period int\) \*WeightedAveragePriceStrategy](<#NewWeightedAveragePriceStrategyWith>)
+  - [func \(v \*WeightedAveragePriceStrategy\) Compute\(snapshots \<\-chan \*asset.Snapshot\) \<\-chan strategy.Action](<#WeightedAveragePriceStrategy.Compute>)
+  - [func \(v \*WeightedAveragePriceStrategy\) Name\(\) string](<#WeightedAveragePriceStrategy.Name>)
+  - [func \(v \*WeightedAveragePriceStrategy\) Report\(c \<\-chan \*asset.Snapshot\) \*helper.Report](<#WeightedAveragePriceStrategy.Report>)
 
 
 ## Constants
@@ -390,59 +390,59 @@ func (n *NegativeVolumeIndexStrategy) Report(c <-chan *asset.Snapshot) *helper.R
 
 Report processes the provided asset snapshots and generates a report annotated with the recommended actions.
 
-<a name="VolumeWeightedAveragePriceStrategy"></a>
-## type [VolumeWeightedAveragePriceStrategy](<https://github.com/cinar/indicator/blob/master/strategy/volume/volume_weighted_average_price_strategy.go#L19-L22>)
+<a name="WeightedAveragePriceStrategy"></a>
+## type [WeightedAveragePriceStrategy](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L19-L22>)
 
-VolumeWeightedAveragePriceStrategy represents the configuration parameters for calculating the Volume Weighted Average Price strategy. Recommends a Buy action when the closing crosses below the VWAP, recommends a Sell action when the closing crosses above the VWAP, and recommends a Hold action otherwise.
+WeightedAveragePriceStrategy represents the configuration parameters for calculating the Volume Weighted Average Price strategy. Recommends a Buy action when the closing crosses below the VWAP, recommends a Sell action when the closing crosses above the VWAP, and recommends a Hold action otherwise.
 
 ```go
-type VolumeWeightedAveragePriceStrategy struct {
+type WeightedAveragePriceStrategy struct {
     // VolumeWeightedAveragePrice is the Volume Weighted Average Price indicator instance.
     VolumeWeightedAveragePrice *volume.Vwap[float64]
 }
 ```
 
-<a name="NewVolumeWeightedAveragePriceStrategy"></a>
-### func [NewVolumeWeightedAveragePriceStrategy](<https://github.com/cinar/indicator/blob/master/strategy/volume/volume_weighted_average_price_strategy.go#L26>)
+<a name="NewWeightedAveragePriceStrategy"></a>
+### func [NewWeightedAveragePriceStrategy](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L26>)
 
 ```go
-func NewVolumeWeightedAveragePriceStrategy() *VolumeWeightedAveragePriceStrategy
+func NewWeightedAveragePriceStrategy() *WeightedAveragePriceStrategy
 ```
 
-NewVolumeWeightedAveragePriceStrategy function initializes a new Volume Weighted Average Price strategy instance with the default parameters.
+NewWeightedAveragePriceStrategy function initializes a new Volume Weighted Average Price strategy instance with the default parameters.
 
-<a name="NewVolumeWeightedAveragePriceStrategyWith"></a>
-### func [NewVolumeWeightedAveragePriceStrategyWith](<https://github.com/cinar/indicator/blob/master/strategy/volume/volume_weighted_average_price_strategy.go#L34>)
+<a name="NewWeightedAveragePriceStrategyWith"></a>
+### func [NewWeightedAveragePriceStrategyWith](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L34>)
 
 ```go
-func NewVolumeWeightedAveragePriceStrategyWith(period int) *VolumeWeightedAveragePriceStrategy
+func NewWeightedAveragePriceStrategyWith(period int) *WeightedAveragePriceStrategy
 ```
 
-NewVolumeWeightedAveragePriceStrategyWith function initializes a new Volume Weighted Average Price strategy instance with the given parameters.
+NewWeightedAveragePriceStrategyWith function initializes a new Volume Weighted Average Price strategy instance with the given parameters.
 
-<a name="VolumeWeightedAveragePriceStrategy.Compute"></a>
-### func \(\*VolumeWeightedAveragePriceStrategy\) [Compute](<https://github.com/cinar/indicator/blob/master/strategy/volume/volume_weighted_average_price_strategy.go#L46>)
+<a name="WeightedAveragePriceStrategy.Compute"></a>
+### func \(\*WeightedAveragePriceStrategy\) [Compute](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L46>)
 
 ```go
-func (v *VolumeWeightedAveragePriceStrategy) Compute(snapshots <-chan *asset.Snapshot) <-chan strategy.Action
+func (v *WeightedAveragePriceStrategy) Compute(snapshots <-chan *asset.Snapshot) <-chan strategy.Action
 ```
 
 Compute processes the provided asset snapshots and generates a stream of actionable recommendations.
 
-<a name="VolumeWeightedAveragePriceStrategy.Name"></a>
-### func \(\*VolumeWeightedAveragePriceStrategy\) [Name](<https://github.com/cinar/indicator/blob/master/strategy/volume/volume_weighted_average_price_strategy.go#L41>)
+<a name="WeightedAveragePriceStrategy.Name"></a>
+### func \(\*WeightedAveragePriceStrategy\) [Name](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L41>)
 
 ```go
-func (v *VolumeWeightedAveragePriceStrategy) Name() string
+func (v *WeightedAveragePriceStrategy) Name() string
 ```
 
 Name returns the name of the strategy.
 
-<a name="VolumeWeightedAveragePriceStrategy.Report"></a>
-### func \(\*VolumeWeightedAveragePriceStrategy\) [Report](<https://github.com/cinar/indicator/blob/master/strategy/volume/volume_weighted_average_price_strategy.go#L78>)
+<a name="WeightedAveragePriceStrategy.Report"></a>
+### func \(\*WeightedAveragePriceStrategy\) [Report](<https://github.com/cinar/indicator/blob/master/strategy/volume/weighted_average_price_strategy.go#L78>)
 
 ```go
-func (v *VolumeWeightedAveragePriceStrategy) Report(c <-chan *asset.Snapshot) *helper.Report
+func (v *WeightedAveragePriceStrategy) Report(c <-chan *asset.Snapshot) *helper.Report
 ```
 
 Report processes the provided asset snapshots and generates a report annotated with the recommended actions.

--- a/strategy/volume/volume.go
+++ b/strategy/volume/volume.go
@@ -30,6 +30,6 @@ func AllStrategies() []strategy.Strategy {
 		NewForceIndexStrategy(),
 		NewMoneyFlowIndexStrategy(),
 		NewNegativeVolumeIndexStrategy(),
-		NewVolumeWeightedAveragePriceStrategy(),
+		NewWeightedAveragePriceStrategy(),
 	}
 }

--- a/strategy/volume/weighted_average_price_strategy.go
+++ b/strategy/volume/weighted_average_price_strategy.go
@@ -13,37 +13,37 @@ import (
 	"github.com/cinar/indicator/v2/volume"
 )
 
-// VolumeWeightedAveragePriceStrategy represents the configuration parameters for calculating the Volume Weighted
+// WeightedAveragePriceStrategy represents the configuration parameters for calculating the Volume Weighted
 // Average Price strategy. Recommends a Buy action when the closing crosses below the VWAP, recommends a Sell
 // action when the closing crosses above the VWAP, and recommends a Hold action otherwise.
-type VolumeWeightedAveragePriceStrategy struct {
+type WeightedAveragePriceStrategy struct {
 	// VolumeWeightedAveragePrice is the Volume Weighted Average Price indicator instance.
 	VolumeWeightedAveragePrice *volume.Vwap[float64]
 }
 
-// NewVolumeWeightedAveragePriceStrategy function initializes a new Volume Weighted Average Price strategy
+// NewWeightedAveragePriceStrategy function initializes a new Volume Weighted Average Price strategy
 // instance with the default parameters.
-func NewVolumeWeightedAveragePriceStrategy() *VolumeWeightedAveragePriceStrategy {
-	return NewVolumeWeightedAveragePriceStrategyWith(
+func NewWeightedAveragePriceStrategy() *WeightedAveragePriceStrategy {
+	return NewWeightedAveragePriceStrategyWith(
 		volume.DefaultVwapPeriod,
 	)
 }
 
-// NewVolumeWeightedAveragePriceStrategyWith function initializes a new Volume Weighted Average Price strategy
+// NewWeightedAveragePriceStrategyWith function initializes a new Volume Weighted Average Price strategy
 // instance with the given parameters.
-func NewVolumeWeightedAveragePriceStrategyWith(period int) *VolumeWeightedAveragePriceStrategy {
-	return &VolumeWeightedAveragePriceStrategy{
+func NewWeightedAveragePriceStrategyWith(period int) *WeightedAveragePriceStrategy {
+	return &WeightedAveragePriceStrategy{
 		VolumeWeightedAveragePrice: volume.NewVwapWithPeriod[float64](period),
 	}
 }
 
 // Name returns the name of the strategy.
-func (v *VolumeWeightedAveragePriceStrategy) Name() string {
+func (v *WeightedAveragePriceStrategy) Name() string {
 	return fmt.Sprintf("Volume Weighted Average Price Strategy (%d)", v.VolumeWeightedAveragePrice.IdlePeriod()+1)
 }
 
 // Compute processes the provided asset snapshots and generates a stream of actionable recommendations.
-func (v *VolumeWeightedAveragePriceStrategy) Compute(snapshots <-chan *asset.Snapshot) <-chan strategy.Action {
+func (v *WeightedAveragePriceStrategy) Compute(snapshots <-chan *asset.Snapshot) <-chan strategy.Action {
 	snapshotsSplice := helper.Duplicate(snapshots, 2)
 
 	closingsSplice := helper.Duplicate(
@@ -75,7 +75,7 @@ func (v *VolumeWeightedAveragePriceStrategy) Compute(snapshots <-chan *asset.Sna
 }
 
 // Report processes the provided asset snapshots and generates a report annotated with the recommended actions.
-func (v *VolumeWeightedAveragePriceStrategy) Report(c <-chan *asset.Snapshot) *helper.Report {
+func (v *WeightedAveragePriceStrategy) Report(c <-chan *asset.Snapshot) *helper.Report {
 	//
 	// snapshots[0] -> dates
 	// snapshots[1] -> closings[0] -> closings

--- a/strategy/volume/weighted_average_price_strategy_test.go
+++ b/strategy/volume/weighted_average_price_strategy_test.go
@@ -27,7 +27,7 @@ func TestVolumeWeightedAveragePriceStrategy(t *testing.T) {
 
 	expected := helper.Map(results, func(r *strategy.Result) strategy.Action { return r.Action })
 
-	vwaps := volume.NewVolumeWeightedAveragePriceStrategy()
+	vwaps := volume.NewWeightedAveragePriceStrategy()
 	actual := vwaps.Compute(snapshots)
 
 	err = helper.CheckEquals(actual, expected)
@@ -42,7 +42,7 @@ func TestVolumeWeightedAveragePriceStrategyReport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vwaps := volume.NewVolumeWeightedAveragePriceStrategy()
+	vwaps := volume.NewWeightedAveragePriceStrategy()
 	report := vwaps.Report(snapshots)
 
 	fileName := "volume_weighted_average_price_strategy.html"


### PR DESCRIPTION
# Describe Request

Rename Volume Weighted Price Strategy to Weighted Price Strategy.

# Change Type

Lint fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Major Improvements" section in the documentation highlighting enhancements in version 2, including improved code quality and testability.
	- Updated lists of indicators and strategies to reflect current offerings, including a renamed strategy.

- **Bug Fixes**
	- Corrected references for the "Volume Weighted Average Price Strategy" to the new name "Weighted Average Price Strategy" across documentation and code.

- **Documentation**
	- Enhanced clarity and organization of the README, including sections on repositories, backtesting, usage instructions, and contributing guidelines.

- **Refactor**
	- Renamed `VolumeWeightedAveragePriceStrategy` to `WeightedAveragePriceStrategy`, updating all related references and documentation accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->