### PR TITLE
Add Martin Pring's Special K to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following list of indicators are currently supported by this package:
 -	[Ichimoku Cloud](momentum/README.md#type-ichimokucloud)
 -	[Percentage Price Oscillator (PPO)](momentum/README.md#type-ppo)
 -	[Percentage Volume Oscillator (PVO)](momentum/README.md#type-pvo)
+-   [Martin Pring's Special K](momentum/README.md#PringsSpecialK)
 -	[Relative Strength Index (RSI)](momentum/README.md#type-rsi)
 -	[Qstick](momentum/README.md#type-qstick)
 -	[Stochastic Oscillator](momentum/README.md#type-stochasticoscillator)

--- a/momentum/README.md
+++ b/momentum/README.md
@@ -41,6 +41,9 @@ The information provided on this project is strictly for informational purposes 
   - [func NewPpo\[T helper.Number\]\(\) \*Ppo\[T\]](<#NewPpo>)
   - [func \(p \*Ppo\[T\]\) Compute\(closings \<\-chan T\) \(\<\-chan T, \<\-chan T, \<\-chan T\)](<#Ppo[T].Compute>)
   - [func \(p \*Ppo\[T\]\) IdlePeriod\(\) int](<#Ppo[T].IdlePeriod>)
+- [type PringsSpecialK](<#PringsSpecialK>)
+  - [func NewPringsSpecialK\[T helper.Float\]\(\) \*PringsSpecialK\[T\]](<#NewPringsSpecialK>)
+  - [func \(p \*PringsSpecialK\[T\]\) Compute\(closings \<\-chan T\) \<\-chan T](<#PringsSpecialK[T].Compute>)
 - [type Pvo](<#Pvo>)
   - [func NewPvo\[T helper.Number\]\(\) \*Pvo\[T\]](<#NewPvo>)
   - [func \(p \*Pvo\[T\]\) Compute\(volumes \<\-chan T\) \(\<\-chan T, \<\-chan T, \<\-chan T\)](<#Pvo[T].Compute>)
@@ -430,6 +433,59 @@ func (p *Ppo[T]) IdlePeriod() int
 ```
 
 IdlePeriod is the initial period that Percentage Price Oscillator won't yield any results.
+
+<a name="PringsSpecialK"></a>
+## type [PringsSpecialK](<https://github.com/cinar/indicator/blob/master/momentum/prings_special_k.go#L12-L38>)
+
+PringsSpecialK implements Martin Pring's Special K momentum indicator. It composes multiple Rate\-of\-Change \(ROC\) series smoothed by Simple Moving Averages \(SMA\) and outputs a weighted sum aligned to the slowest path so all terms are time\-synchronized. See Compute for the exact composition and weights.
+
+```go
+type PringsSpecialK[T helper.Float] struct {
+    Roc10  *trend.Roc[T]
+    Roc15  *trend.Roc[T]
+    Roc20  *trend.Roc[T]
+    Roc30  *trend.Roc[T]
+    Roc40  *trend.Roc[T]
+    Roc65  *trend.Roc[T]
+    Roc75  *trend.Roc[T]
+    Roc100 *trend.Roc[T]
+    Roc195 *trend.Roc[T]
+    Roc265 *trend.Roc[T]
+    Roc390 *trend.Roc[T]
+    Roc530 *trend.Roc[T]
+
+    Sma10Roc10   *trend.Sma[T]
+    Sma10Roc15   *trend.Sma[T]
+    Sma10Roc20   *trend.Sma[T]
+    Sma15Roc30   *trend.Sma[T]
+    Sma50Roc40   *trend.Sma[T]
+    Sma65Roc65   *trend.Sma[T]
+    Sma75Roc75   *trend.Sma[T]
+    Sma100Roc100 *trend.Sma[T]
+    Sma130Roc195 *trend.Sma[T]
+    Sma130Roc265 *trend.Sma[T]
+    Sma130Roc390 *trend.Sma[T]
+    Sma195Roc530 *trend.Sma[T]
+}
+```
+
+<a name="NewPringsSpecialK"></a>
+### func [NewPringsSpecialK](<https://github.com/cinar/indicator/blob/master/momentum/prings_special_k.go#L41>)
+
+```go
+func NewPringsSpecialK[T helper.Float]() *PringsSpecialK[T]
+```
+
+NewPringsSpecialK function initializes a new Martin Pring's Special K instance.
+
+<a name="PringsSpecialK[T].Compute"></a>
+### func \(\*PringsSpecialK\[T\]\) [Compute](<https://github.com/cinar/indicator/blob/master/momentum/prings_special_k.go#L72>)
+
+```go
+func (p *PringsSpecialK[T]) Compute(closings <-chan T) <-chan T
+```
+
+Compute function takes a channel of numbers and computes the Prings Special K.
 
 <a name="Pvo"></a>
 ## type [Pvo](<https://github.com/cinar/indicator/blob/master/momentum/pvo.go#L35-L44>)


### PR DESCRIPTION
# Describe Request

Add Martin Pring's Special K to documentation.

Fixed # (issue)

# Change Type

Fix documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Martin Pring’s Special K momentum indicator, providing an advanced, long- and short-term trend momentum view by combining multiple smoothed rate-of-change components into a single signal.
  - Available for use in momentum analysis workflows with time-synchronized output.

- Documentation
  - Updated README to include Martin Pring’s Special K in the Momentum Indicators list and added usage details for the new indicator.

- Chores
  - No functional changes outside the new indicator; no breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->