### PR TITLE
fix: correct "Community Channel Index" to "Commodity Channel Index" (CCI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following list of indicators are currently supported by this package:
 -	[Aroon Indicator](trend/README.md#type-aroon)
 -	[Balance of Power (BoP)](trend/README.md#type-bop)
 -	Chande Forecast Oscillator (CFO)
--	[Community Channel Index (CCI)](trend/README.md#type-cci)
+-	[Commodity Channel Index (CCI)](trend/README.md#type-cci)
 -   [Envelope](trend/README.md#type-envelope)
 -	[Hull Moving Average (HMA)](trend/README.md#type-hma)
 -   [Detrended Price Oscillator (DPO)](trend/README.md#type-dpo)
@@ -126,7 +126,7 @@ The following list of strategies are currently supported by this package:
 -	[Aroon Strategy](strategy/trend/README.md#type-aroonstrategy)
 -	[Balance of Power (BoP) Strategy](strategy/trend/README.md#type-bopstrategy)
 -	Chande Forecast Oscillator Strategy
--	[Community Channel Index (CCI) Strategy](strategy/trend/README.md#type-ccistrategy)
+-	[Commodity Channel Index (CCI) Strategy](strategy/trend/README.md#type-ccistrategy)
 -	[Double Exponential Moving Average (DEMA) Strategy](strategy/trend/README.md#type-demastrategy)
 -   [Envelope Strategy](strategy/trend/README.md#type-envelope)
 -	[Golden Cross Strategy](strategy/trend/README.md#type-goldencrossstrategy)

--- a/trend/README.md
+++ b/trend/README.md
@@ -507,7 +507,7 @@ Compute processes a channel of open, high, low, and close values, computing the 
 <a name="Cci"></a>
 ## type [Cci](<https://github.com/cinar/indicator/blob/master/trend/cci.go#L29-L32>)
 
-Cci represents the configuration parameters for calculating the Community Channel Index \(CCI\). CCI is a momentum\-based oscillator used to help determine when an investment vehicle is reaching a condition of being overbought or oversold.
+Cci represents the configuration parameters for calculating the Commodity Channel Index \(CCI\). CCI is a momentum\-based oscillator used to help determine when an investment vehicle is reaching a condition of being overbought or oversold.
 
 ```
 Moving Average = Sma(Period, Typical Price)

--- a/trend/cci.go
+++ b/trend/cci.go
@@ -13,7 +13,7 @@ const (
 	DefaultCciPeriod = 20
 )
 
-// Cci represents the configuration parameters for calculating the Community Channel Index (CCI). CCI is a
+// Cci represents the configuration parameters for calculating the Commodity Channel Index (CCI). CCI is a
 // momentum-based oscillator used to help determine when an investment vehicle is reaching a condition of
 // being overbought or oversold.
 //


### PR DESCRIPTION
CCI stands for **Commodity Channel Index**, not "Community Channel Index". This is a well-known technical analysis indicator created by Donald Lambert in 1980.

### Changes
- `README.md` — fixed indicator and strategy listing names
- `trend/README.md` — fixed type documentation
- `trend/cci.go` — fixed Go doc comment

Small typo fix, no logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CCI indicator naming to reflect "Commodity Channel Index" across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->