### PR TITLE
Implement Pivot Point indicator. (#302)

### DIFF
--- a/trend/GEMINI.md
+++ b/trend/GEMINI.md
@@ -6,7 +6,7 @@ The `trend` package provides a collection of indicators used for identifying and
 
 - **Moving Averages:** `Sma` (Simple), `Ema` (Exponential), `Dema` (Double), `Tema` (Triple), `Wma` (Weighted), `Hma` (Hull), `Kama` (Kaufman), `Smma` (Smoothed), `Vwma` (Volume Weighted).
 - **Oscillators:** `Apo` (Absolute Price Oscillator), `Cci` (Commodity Channel Index), `Dpo` (Detrended Price Oscillator), `Trix` (Triple Exponential Average).
-- **Indicators:** `Aroon` (Aroon Oscillator), `Bop` (Balance of Power), `Macd` (Moving Average Convergence Divergence), `Roc` (Rate of Change), `Tsi` (True Strength Index).
+- **Indicators:** `Aroon` (Aroon Oscillator), `Bop` (Balance of Power), `Macd` (Moving Average Convergence Divergence), `PivotPoint` (Standard, Woodie, Camarilla, Fibonacci), `Roc` (Rate of Change), `Tsi` (True Strength Index).
 - **Utilities:** `MovingMax`, `MovingMin`, `MovingSum`, `TypicalPrice`.
 
 ## Common Pattern

--- a/trend/README.md
+++ b/trend/README.md
@@ -127,6 +127,14 @@ The information provided on this project is strictly for informational purposes 
   - [func NewMovingSumWithPeriod\[T helper.Number\]\(period int\) \*MovingSum\[T\]](<#NewMovingSumWithPeriod>)
   - [func \(m \*MovingSum\[T\]\) Compute\(c \<\-chan T\) \<\-chan T](<#MovingSum[T].Compute>)
   - [func \(m \*MovingSum\[T\]\) IdlePeriod\(\) int](<#MovingSum[T].IdlePeriod>)
+- [type PivotPoint](<#PivotPoint>)
+  - [func NewPivotPoint\[T helper.Float\]\(\) \*PivotPoint\[T\]](<#NewPivotPoint>)
+  - [func NewPivotPointWithMethod\[T helper.Float\]\(method PivotPointMethod\) \*PivotPoint\[T\]](<#NewPivotPointWithMethod>)
+  - [func \(p \*PivotPoint\[T\]\) Compute\(opens, highs, lows, closings \<\-chan T\) \<\-chan PivotPointResult\[T\]](<#PivotPoint[T].Compute>)
+  - [func \(p \*PivotPoint\[T\]\) IdlePeriod\(\) int](<#PivotPoint[T].IdlePeriod>)
+  - [func \(p \*PivotPoint\[T\]\) String\(\) string](<#PivotPoint[T].String>)
+- [type PivotPointMethod](<#PivotPointMethod>)
+- [type PivotPointResult](<#PivotPointResult>)
 - [type Rma](<#Rma>)
   - [func NewRma\[T helper.Number\]\(\) \*Rma\[T\]](<#NewRma>)
   - [func NewRmaWithPeriod\[T helper.Number\]\(period int\) \*Rma\[T\]](<#NewRmaWithPeriod>)
@@ -1789,6 +1797,109 @@ func (m *MovingSum[T]) IdlePeriod() int
 ```
 
 IdlePeriod is the initial period that Moving Sum won't yield any results.
+
+<a name="PivotPoint"></a>
+## type [PivotPoint](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L47-L50>)
+
+PivotPoint represents the configuration parameters for calculating Pivot Points. Pivot points are calculated based on the previous period's high, low, and close, and are used to predict support and resistance levels for the current period.
+
+```go
+type PivotPoint[T helper.Float] struct {
+    // Method is the pivot point calculation method.
+    Method PivotPointMethod
+}
+```
+
+<a name="NewPivotPoint"></a>
+### func [NewPivotPoint](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L53>)
+
+```go
+func NewPivotPoint[T helper.Float]() *PivotPoint[T]
+```
+
+NewPivotPoint function initializes a new Pivot Point instance with the standard method.
+
+<a name="NewPivotPointWithMethod"></a>
+### func [NewPivotPointWithMethod](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L58>)
+
+```go
+func NewPivotPointWithMethod[T helper.Float](method PivotPointMethod) *PivotPoint[T]
+```
+
+NewPivotPointWithMethod function initializes a new Pivot Point instance with the given method.
+
+<a name="PivotPoint[T].Compute"></a>
+### func \(\*PivotPoint\[T\]\) [Compute](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L67>)
+
+```go
+func (p *PivotPoint[T]) Compute(opens, highs, lows, closings <-chan T) <-chan PivotPointResult[T]
+```
+
+Compute function takes channels for open, high, low, and closing prices and returns a channel of PivotPointResult. It uses the values from the previous period to calculate levels for the current period.
+
+<a name="PivotPoint[T].IdlePeriod"></a>
+### func \(\*PivotPoint\[T\]\) [IdlePeriod](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L150>)
+
+```go
+func (p *PivotPoint[T]) IdlePeriod() int
+```
+
+IdlePeriod is the initial period that Pivot Point won't yield any results.
+
+<a name="PivotPoint[T].String"></a>
+### func \(\*PivotPoint\[T\]\) [String](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L155>)
+
+```go
+func (p *PivotPoint[T]) String() string
+```
+
+String is the string representation of the Pivot Point instance.
+
+<a name="PivotPointMethod"></a>
+## type [PivotPointMethod](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L14>)
+
+PivotPointMethod represents the method used for calculating pivot points.
+
+```go
+type PivotPointMethod int
+```
+
+<a name="PivotPointStandard"></a>
+
+```go
+const (
+    // PivotPointStandard is the standard pivot point calculation.
+    PivotPointStandard PivotPointMethod = iota
+
+    // PivotPointWoodie is the Woodie pivot point calculation.
+    PivotPointWoodie
+
+    // PivotPointCamarilla is the Camarilla pivot point calculation.
+    PivotPointCamarilla
+
+    // PivotPointFibonacci is the Fibonacci pivot point calculation.
+    PivotPointFibonacci
+)
+```
+
+<a name="PivotPointResult"></a>
+## type [PivotPointResult](<https://github.com/cinar/indicator/blob/master/trend/pivot_point.go#L32-L42>)
+
+PivotPointResult represents the result of the pivot point calculation, including the pivot point itself, and its associated resistance \(R\) and support \(S\) levels.
+
+```go
+type PivotPointResult[T helper.Float] struct {
+    P   T
+    R1  T
+    R2  T
+    R3  T
+    R4  T
+    S1  T
+    S2  T
+    S3  T
+    S4  T
+}
+```
 
 <a name="Rma"></a>
 ## type [Rma](<https://github.com/cinar/indicator/blob/master/trend/rma.go#L25-L28>)

--- a/trend/pivot_point.go
+++ b/trend/pivot_point.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2021-2026 Onur Cinar.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package trend
+
+import (
+	"fmt"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+// PivotPointMethod represents the method used for calculating pivot points.
+type PivotPointMethod int
+
+const (
+	// PivotPointStandard is the standard pivot point calculation.
+	PivotPointStandard PivotPointMethod = iota
+
+	// PivotPointWoodie is the Woodie pivot point calculation.
+	PivotPointWoodie
+
+	// PivotPointCamarilla is the Camarilla pivot point calculation.
+	PivotPointCamarilla
+
+	// PivotPointFibonacci is the Fibonacci pivot point calculation.
+	PivotPointFibonacci
+)
+
+// PivotPointResult represents the result of the pivot point calculation, including
+// the pivot point itself, and its associated resistance (R) and support (S) levels.
+type PivotPointResult[T helper.Float] struct {
+	P  T
+	R1 T
+	R2 T
+	R3 T
+	R4 T
+	S1 T
+	S2 T
+	S3 T
+	S4 T
+}
+
+// PivotPoint represents the configuration parameters for calculating Pivot Points.
+// Pivot points are calculated based on the previous period's high, low, and close,
+// and are used to predict support and resistance levels for the current period.
+type PivotPoint[T helper.Float] struct {
+	// Method is the pivot point calculation method.
+	Method PivotPointMethod
+}
+
+// NewPivotPoint function initializes a new Pivot Point instance with the standard method.
+func NewPivotPoint[T helper.Float]() *PivotPoint[T] {
+	return NewPivotPointWithMethod[T](PivotPointStandard)
+}
+
+// NewPivotPointWithMethod function initializes a new Pivot Point instance with the given method.
+func NewPivotPointWithMethod[T helper.Float](method PivotPointMethod) *PivotPoint[T] {
+	return &PivotPoint[T]{
+		Method: method,
+	}
+}
+
+// Compute function takes channels for open, high, low, and closing prices and
+// returns a channel of PivotPointResult. It uses the values from the previous
+// period to calculate levels for the current period.
+func (p *PivotPoint[T]) Compute(opens, highs, lows, closings <-chan T) <-chan PivotPointResult[T] {
+	result := make(chan PivotPointResult[T], cap(closings))
+
+	go func() {
+		defer close(result)
+
+		var prevH, prevL, prevC T
+		first := true
+
+		for {
+			o, okO := <-opens
+			h, okH := <-highs
+			l, okL := <-lows
+			c, okC := <-closings
+
+			if !okO || !okH || !okL || !okC {
+				break
+			}
+
+			if !first {
+				result <- p.calculate(prevH, prevL, prevC, o)
+			}
+
+			prevH, prevL, prevC = h, l, c
+			first = false
+		}
+	}()
+
+	return result
+}
+
+// calculate calculates the pivot points using the specified method.
+func (p *PivotPoint[T]) calculate(h, l, c, currO T) PivotPointResult[T] {
+	var res PivotPointResult[T]
+
+	switch p.Method {
+	case PivotPointStandard:
+		res.P = (h + l + c) / 3
+		res.R1 = 2*res.P - l
+		res.S1 = 2*res.P - h
+		res.R2 = res.P + (h - l)
+		res.S2 = res.P - (h - l)
+		res.R3 = h + 2*(res.P-l)
+		res.S3 = l - 2*(h-res.P)
+		res.R4 = h + 3*(res.P-l)
+		res.S4 = l - 3*(h-res.P)
+
+	case PivotPointWoodie:
+		res.P = (h + l + 2*currO) / 4
+		res.R1 = 2*res.P - l
+		res.S1 = 2*res.P - h
+		res.R2 = res.P + (h - l)
+		res.S2 = res.P - (h - l)
+		res.R3 = h + 2*(res.P-l)
+		res.S3 = l - 2*(h-res.P)
+
+	case PivotPointCamarilla:
+		diff := h - l
+		res.P = (h + l + c) / 3
+		res.R1 = c + diff*T(1.1)/12
+		res.R2 = c + diff*T(1.1)/6
+		res.R3 = c + diff*T(1.1)/4
+		res.R4 = c + diff*T(1.1)/2
+		res.S1 = c - diff*T(1.1)/12
+		res.S2 = c - diff*T(1.1)/6
+		res.S3 = c - diff*T(1.1)/4
+		res.S4 = c - diff*T(1.1)/2
+
+	case PivotPointFibonacci:
+		diff := h - l
+		res.P = (h + l + c) / 3
+		res.R1 = res.P + diff*T(0.382)
+		res.S1 = res.P - diff*T(0.382)
+		res.R2 = res.P + diff*T(0.618)
+		res.S2 = res.P - diff*T(0.618)
+		res.R3 = res.P + diff*T(1.000)
+		res.S3 = res.P - diff*T(1.000)
+	}
+
+	return res
+}
+
+// IdlePeriod is the initial period that Pivot Point won't yield any results.
+func (p *PivotPoint[T]) IdlePeriod() int {
+	return 1
+}
+
+// String is the string representation of the Pivot Point instance.
+func (p *PivotPoint[T]) String() string {
+	var methodStr string
+	switch p.Method {
+	case PivotPointStandard:
+		methodStr = "Standard"
+	case PivotPointWoodie:
+		methodStr = "Woodie"
+	case PivotPointCamarilla:
+		methodStr = "Camarilla"
+	case PivotPointFibonacci:
+		methodStr = "Fibonacci"
+	}
+	return fmt.Sprintf("PivotPoint(%s)", methodStr)
+}

--- a/trend/pivot_point_test.go
+++ b/trend/pivot_point_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2021-2026 Onur Cinar.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package trend_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/helper"
+	"github.com/cinar/indicator/v2/trend"
+)
+
+func TestPivotPoint(t *testing.T) {
+	type Data struct {
+		Open  float64 `header:"Open"`
+		High  float64 `header:"High"`
+		Low   float64 `header:"Low"`
+		Close float64 `header:"Close"`
+	}
+
+	input, err := helper.ReadFromCsvFile[Data]("../helper/testdata/report.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputs := helper.Duplicate(input, 4)
+	opens := helper.Map(inputs[0], func(d *Data) float64 { return d.Open })
+	highs := helper.Map(inputs[1], func(d *Data) float64 { return d.High })
+	lows := helper.Map(inputs[2], func(d *Data) float64 { return d.Low })
+	closings := helper.Map(inputs[3], func(d *Data) float64 { return d.Close })
+
+	pp := trend.NewPivotPoint[float64]()
+	results := pp.Compute(opens, highs, lows, closings)
+
+	// First bar: 315.130005, 318.600006, 308.700012, 318.600006
+	// Second bar Open: 319
+	// Standard Pivot Point for second bar:
+	// P = (318.600006 + 308.700012 + 318.600006) / 3 = 315.300008
+	// R1 = 2 * 315.300008 - 308.700012 = 321.900004
+	// S1 = 2 * 315.300008 - 318.600006 = 312.00001
+
+	res := <-results
+
+	if helper.RoundDigit(res.P, 6) != 315.300008 {
+		t.Fatalf("expected P 315.300008, got %v", res.P)
+	}
+
+	if helper.RoundDigit(res.R1, 6) != 321.900004 {
+		t.Fatalf("expected R1 321.900004, got %v", res.R1)
+	}
+
+	if helper.RoundDigit(res.S1, 6) != 312.00001 {
+		t.Fatalf("expected S1 312.00001, got %v", res.S1)
+	}
+}
+
+func TestPivotPointWoodie(t *testing.T) {
+	type Data struct {
+		Open  float64 `header:"Open"`
+		High  float64 `header:"High"`
+		Low   float64 `header:"Low"`
+		Close float64 `header:"Close"`
+	}
+
+	input, err := helper.ReadFromCsvFile[Data]("../helper/testdata/report.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputs := helper.Duplicate(input, 4)
+	opens := helper.Map(inputs[0], func(d *Data) float64 { return d.Open })
+	highs := helper.Map(inputs[1], func(d *Data) float64 { return d.High })
+	lows := helper.Map(inputs[2], func(d *Data) float64 { return d.Low })
+	closings := helper.Map(inputs[3], func(d *Data) float64 { return d.Close })
+
+	pp := trend.NewPivotPointWithMethod[float64](trend.PivotPointWoodie)
+	results := pp.Compute(opens, highs, lows, closings)
+
+	// First bar: H=318.600006, L=308.700012
+	// Second bar: O=319
+	// Woodie P = (318.600006 + 308.700012 + 2 * 319) / 4 = 316.3250045
+
+	res := <-results
+
+	if helper.RoundDigit(res.P, 7) != 316.3250045 {
+		t.Fatalf("expected P 316.3250045, got %v", res.P)
+	}
+}
+
+func TestPivotPointIdlePeriod(t *testing.T) {
+	pp := trend.NewPivotPoint[float64]()
+	if pp.IdlePeriod() != 1 {
+		t.Fatalf("expected IdlePeriod 1, got %d", pp.IdlePeriod())
+	}
+}
+
+func TestPivotPointString(t *testing.T) {
+	pp := trend.NewPivotPoint[float64]()
+	if pp.String() != "PivotPoint(Standard)" {
+		t.Fatalf("expected PivotPoint(Standard), got %s", pp.String())
+	}
+
+	pp = trend.NewPivotPointWithMethod[float64](trend.PivotPointWoodie)
+	if pp.String() != "PivotPoint(Woodie)" {
+		t.Fatalf("expected PivotPoint(Woodie), got %s", pp.String())
+	}
+
+	pp = trend.NewPivotPointWithMethod[float64](trend.PivotPointCamarilla)
+	if pp.String() != "PivotPoint(Camarilla)" {
+		t.Fatalf("expected PivotPoint(Camarilla), got %s", pp.String())
+	}
+
+	pp = trend.NewPivotPointWithMethod[float64](trend.PivotPointFibonacci)
+	if pp.String() != "PivotPoint(Fibonacci)" {
+		t.Fatalf("expected PivotPoint(Fibonacci), got %s", pp.String())
+	}
+}


### PR DESCRIPTION
This PR implements the Pivot Point indicator in the trend package. It supports Standard, Woodie, Camarilla, and Fibonacci calculation methods. The indicator uses the previous period's OHLC data to calculate support and resistance levels for the current period.

Fixed #302