### PR TITLE
feat(volatility): add historical volatility indicator

### DIFF
--- a/volatility/historical_volatility.go
+++ b/volatility/historical_volatility.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021-2026 Onur Cinar.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package volatility
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+const (
+	// DefaultHistoricalVolatilityPeriod is the default period for Historical Volatility (HV).
+	DefaultHistoricalVolatilityPeriod = 21
+)
+
+// HistoricalVolatility represents the configuration parameters for calculating Historical Volatility (HV).
+//
+//	HV = StdDev(R_t, n)
+//	where R_t = (P_t / P_(t-1)) - 1
+type HistoricalVolatility[T helper.Number] struct {
+	// Time period.
+	Period int
+}
+
+// NewHistoricalVolatility function initializes a new Historical Volatility instance with the default parameters.
+func NewHistoricalVolatility[T helper.Number]() *HistoricalVolatility[T] {
+	return NewHistoricalVolatilityWithPeriod[T](DefaultHistoricalVolatilityPeriod)
+}
+
+// NewHistoricalVolatilityWithPeriod function initializes a new Historical Volatility instance with the given period.
+func NewHistoricalVolatilityWithPeriod[T helper.Number](period int) *HistoricalVolatility[T] {
+	if period <= 0 {
+		period = DefaultHistoricalVolatilityPeriod
+	}
+
+	return &HistoricalVolatility[T]{
+		Period: period,
+	}
+}
+
+// Compute function takes a channel of prices and computes the Historical Volatility over the specified period.
+func (h *HistoricalVolatility[T]) Compute(prices <-chan T) <-chan T {
+	result := make(chan T, cap(prices))
+
+	go func() {
+		defer close(result)
+
+		returns := helper.NewRing[T](h.Period)
+		sum := T(0)
+		previous, hasPrevious := T(0), false
+
+		for price := range prices {
+			if !hasPrevious {
+				previous = price
+				hasPrevious = true
+				continue
+			}
+
+			r := T(0)
+			if previous != 0 {
+				r = (price / previous) - 1
+			}
+
+			sum -= returns.Put(r)
+			sum += r
+
+			if returns.IsFull() {
+				mean := sum / T(h.Period)
+				sumSquaredDiff := T(0)
+
+				for i := 0; i < h.Period; i++ {
+					sumSquaredDiff += T(math.Pow(float64(returns.At(i)-mean), 2))
+				}
+
+				stdDev := T(math.Sqrt(float64(sumSquaredDiff / T(h.Period))))
+				result <- stdDev
+			}
+
+			previous = price
+		}
+	}()
+
+	return result
+}
+
+// IdlePeriod is the initial period that Historical Volatility won't yield any results.
+func (h *HistoricalVolatility[T]) IdlePeriod() int {
+	// One bar for return series start and period-1 bars for window fill.
+	return h.Period
+}
+
+// String function returns a string representation of the Historical Volatility.
+func (h *HistoricalVolatility[T]) String() string {
+	return fmt.Sprintf("HV(%d)", h.Period)
+}

--- a/volatility/historical_volatility_test.go
+++ b/volatility/historical_volatility_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021-2026 Onur Cinar.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package volatility_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/helper"
+	"github.com/cinar/indicator/v2/volatility"
+)
+
+func TestHistoricalVolatilityDefaultAndString(t *testing.T) {
+	hv := volatility.NewHistoricalVolatility[float64]()
+
+	if hv.Period != volatility.DefaultHistoricalVolatilityPeriod {
+		t.Fatalf("expected period %d, got %d", volatility.DefaultHistoricalVolatilityPeriod, hv.Period)
+	}
+
+	if hv.IdlePeriod() != volatility.DefaultHistoricalVolatilityPeriod {
+		t.Fatalf("expected idle period %d, got %d", volatility.DefaultHistoricalVolatilityPeriod, hv.IdlePeriod())
+	}
+
+	if hv.String() != "HV(21)" {
+		t.Fatalf("expected HV(21), got %s", hv.String())
+	}
+}
+
+func TestHistoricalVolatilityWithInvalidPeriod(t *testing.T) {
+	hv := volatility.NewHistoricalVolatilityWithPeriod[float64](0)
+
+	if hv.Period != volatility.DefaultHistoricalVolatilityPeriod {
+		t.Fatalf("expected default period %d, got %d", volatility.DefaultHistoricalVolatilityPeriod, hv.Period)
+	}
+}
+
+func TestHistoricalVolatilityCompute(t *testing.T) {
+	prices := helper.SliceToChan([]float64{100, 110, 121, 133.1, 146.41, 161.051})
+
+	hv := volatility.NewHistoricalVolatilityWithPeriod[float64](2)
+	actuals := helper.ChanToSlice(hv.Compute(prices))
+
+	expected := []float64{0, 0, 0}
+	if len(actuals) != len(expected) {
+		t.Fatalf("expected %d values, got %d", len(expected), len(actuals))
+	}
+
+	for i := range expected {
+		if actuals[i] != expected[i] {
+			t.Fatalf("at %d expected %v, got %v", i, expected[i], actuals[i])
+		}
+	}
+}
+
+func TestHistoricalVolatilityPreviousPriceZero(t *testing.T) {
+	prices := helper.SliceToChan([]float64{0, 5, 10, 20, 40})
+
+	hv := volatility.NewHistoricalVolatilityWithPeriod[float64](2)
+	actuals := helper.ChanToSlice(hv.Compute(prices))
+
+	expected := []float64{0.5, 0}
+	if len(actuals) != len(expected) {
+		t.Fatalf("expected %d values, got %d", len(expected), len(actuals))
+	}
+
+	for i := range expected {
+		if actuals[i] != expected[i] {
+			t.Fatalf("at %d expected %v, got %v", i, expected[i], actuals[i])
+		}
+	}
+}


### PR DESCRIPTION
# Describe Request

Description
Calculates standard deviation of daily log/simple returns over a period.

Implementation Details
Struct name: HistoricalVolatility[T helper.Number]
Constructor: NewHistoricalVolatility[T helper.Number](), NewHistoricalVolatilityWithPeriod[T helper.Number](period int)
Parameters: period (default: 21)
Functions: Compute(<-chan T) <-chan T, IdlePeriod() int, String() string
Test files with 100% coverage.
Suggested Package
volatility

Fixed #367 (issue)

