### PR TITLE
Fix concurrent map write in DataReport by centralizing report locking

### DIFF
--- a/backtest/backtest.go
+++ b/backtest/backtest.go
@@ -47,6 +47,9 @@ type Backtest struct {
 	// report is the report writer for the backtest.
 	report Report
 
+	// reportMu serializes calls into report across concurrent workers.
+	reportMu sync.Mutex
+
 	// Names is the names of the assets to backtest.
 	Names []string
 
@@ -145,7 +148,9 @@ func (b *Backtest) worker(names <-chan string, wg *sync.WaitGroup) {
 		snapshotsSlice := helper.ChanToSlice(snapshots)
 
 		// Backtesting asset has begun.
+		b.reportMu.Lock()
 		err = b.report.AssetBegin(name, b.Strategies)
+		b.reportMu.Unlock()
 		if err != nil {
 			b.Logger.Error("Unable to begin asset.", "asset", name, "error", err)
 			continue
@@ -156,14 +161,19 @@ func (b *Backtest) worker(names <-chan string, wg *sync.WaitGroup) {
 			snapshotsSplice := helper.Duplicate(helper.SliceToChan(snapshotsSlice), 2)
 
 			actions, outcomes := strategy.ComputeWithOutcome(currentStrategy, snapshotsSplice[0])
+
+			b.reportMu.Lock()
 			err = b.report.Write(name, currentStrategy, snapshotsSplice[1], actions, outcomes)
+			b.reportMu.Unlock()
 			if err != nil {
 				b.Logger.Error("Unable to write report.", "asset", name, "error", err)
 			}
 		}
 
 		// Backtesting asset had ended
+		b.reportMu.Lock()
 		err = b.report.AssetEnd(name)
+		b.reportMu.Unlock()
 		if err != nil {
 			b.Logger.Error("Unable to end asset.", "asset", name, "error", err)
 		}

--- a/backtest/backtest.go
+++ b/backtest/backtest.go
@@ -128,6 +128,15 @@ func (b *Backtest) Run() error {
 	return nil
 }
 
+// withReportLock serializes a call into report across concurrent workers. The
+// mutex is released via defer so it is not left locked if fn panics.
+func (b *Backtest) withReportLock(fn func() error) error {
+	b.reportMu.Lock()
+	defer b.reportMu.Unlock()
+
+	return fn()
+}
+
 // worker is a backtesting worker that concurrently executes backtests for individual
 // assets. It receives asset names from the provided channel, and performs backtests
 // using the given strategies.
@@ -148,9 +157,9 @@ func (b *Backtest) worker(names <-chan string, wg *sync.WaitGroup) {
 		snapshotsSlice := helper.ChanToSlice(snapshots)
 
 		// Backtesting asset has begun.
-		b.reportMu.Lock()
-		err = b.report.AssetBegin(name, b.Strategies)
-		b.reportMu.Unlock()
+		err = b.withReportLock(func() error {
+			return b.report.AssetBegin(name, b.Strategies)
+		})
 		if err != nil {
 			b.Logger.Error("Unable to begin asset.", "asset", name, "error", err)
 			continue
@@ -162,18 +171,18 @@ func (b *Backtest) worker(names <-chan string, wg *sync.WaitGroup) {
 
 			actions, outcomes := strategy.ComputeWithOutcome(currentStrategy, snapshotsSplice[0])
 
-			b.reportMu.Lock()
-			err = b.report.Write(name, currentStrategy, snapshotsSplice[1], actions, outcomes)
-			b.reportMu.Unlock()
+			err = b.withReportLock(func() error {
+				return b.report.Write(name, currentStrategy, snapshotsSplice[1], actions, outcomes)
+			})
 			if err != nil {
 				b.Logger.Error("Unable to write report.", "asset", name, "error", err)
 			}
 		}
 
 		// Backtesting asset had ended
-		b.reportMu.Lock()
-		err = b.report.AssetEnd(name)
-		b.reportMu.Unlock()
+		err = b.withReportLock(func() error {
+			return b.report.AssetEnd(name)
+		})
 		if err != nil {
 			b.Logger.Error("Unable to end asset.", "asset", name, "error", err)
 		}

--- a/backtest/backtest_test.go
+++ b/backtest/backtest_test.go
@@ -58,6 +58,19 @@ func TestBacktestAllAssetsAndStrategies(t *testing.T) {
 	}
 }
 
+func TestBacktestAllAssetsAndStrategiesWithDataReport(t *testing.T) {
+	repository := asset.NewFileSystemRepository("testdata/repository")
+
+	dataReport := backtest.NewDataReport()
+	bt := backtest.NewBacktest(repository, dataReport)
+	bt.Workers = 16
+
+	err := bt.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBacktestNonExistingAsset(t *testing.T) {
 	repository := asset.NewFileSystemRepository("testdata/repository")
 

--- a/backtest/html_report.go
+++ b/backtest/html_report.go
@@ -13,7 +13,6 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
-	"sync"
 	"text/template"
 	"time"
 
@@ -39,9 +38,6 @@ type HTMLReport struct {
 
 	// outputDir is the output directory for the generated reports.
 	outputDir string
-
-	// mu is a mutex that ensures thread safety.
-	mu sync.Mutex
 
 	// assetResults is the mapping from the asset name to strategy results.
 	assetResults map[string][]*htmlReportResult
@@ -106,9 +102,6 @@ func (h *HTMLReport) Begin(assetNames []string, _ []strategy.Strategy) error {
 
 // AssetBegin is called when backtesting for the given asset begins.
 func (h *HTMLReport) AssetBegin(name string, strategies []strategy.Strategy) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	_, ok := h.assetResults[name]
 	if ok {
 		return fmt.Errorf("asset has already begun: %s", name)
@@ -143,9 +136,6 @@ func (h *HTMLReport) Write(assetName string, currentStrategy strategy.Strategy, 
 		go helper.Drain(snapshots)
 	}
 
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	// Get asset strategy results.
 	results, ok := h.assetResults[assetName]
 	if !ok {
@@ -167,9 +157,6 @@ func (h *HTMLReport) Write(assetName string, currentStrategy strategy.Strategy, 
 
 // AssetEnd is called when backtesting for the given asset ends.
 func (h *HTMLReport) AssetEnd(name string) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	results, ok := h.assetResults[name]
 	if !ok {
 		return fmt.Errorf("asset has not begun: %s", name)

--- a/backtest/report.go
+++ b/backtest/report.go
@@ -10,6 +10,10 @@ import (
 )
 
 // Report is the backtest report interface.
+//
+// Backtest serializes all calls into a Report instance across its workers,
+// so implementations do not need to provide their own synchronization even
+// when Backtest.Workers runs multiple assets concurrently.
 type Report interface {
 	// Begin is called when the backtest begins.
 	Begin(assetNames []string, strategies []strategy.Strategy) error

--- a/backtest/report_factory.go
+++ b/backtest/report_factory.go
@@ -6,6 +6,7 @@ package backtest
 
 import (
 	"fmt"
+	"sync"
 )
 
 const (
@@ -16,6 +17,9 @@ const (
 // ReportBuilderFunc defines a function to build a new report using the given configuration parameter.
 type ReportBuilderFunc func(config string) (Report, error)
 
+// reportBuildersMu guards reportBuilders against concurrent registration and lookup.
+var reportBuildersMu sync.RWMutex
+
 // reportBuilders provides mapping for the report builders.
 var reportBuilders = map[string]ReportBuilderFunc{
 	HTMLReportBuilderName: htmlReportBuilder,
@@ -23,12 +27,18 @@ var reportBuilders = map[string]ReportBuilderFunc{
 
 // RegisterReportBuilder registers the given builder.
 func RegisterReportBuilder(name string, builder ReportBuilderFunc) {
+	reportBuildersMu.Lock()
+	defer reportBuildersMu.Unlock()
+
 	reportBuilders[name] = builder
 }
 
 // NewReport builds a new report by the given name type and the configuration.
 func NewReport(name, config string) (Report, error) {
+	reportBuildersMu.RLock()
 	builder, ok := reportBuilders[name]
+	reportBuildersMu.RUnlock()
+
 	if !ok {
 		return nil, fmt.Errorf("unknown report: %s", name)
 	}


### PR DESCRIPTION
Fixes #400.

## Problem

`DataReport.Results` is a plain map, mutated by `AssetBegin`/`Write` with no synchronization, while `Backtest.worker` calls those methods concurrently (one goroutine per `Backtest.Workers`) for different assets. This is the same bug class fixed for `HTMLReport` in #393, but `DataReport` never got the equivalent fix, and it's the report type `mcp/strategy.go` builds its backtest results on.

## Fix

Instead of bolting a second mutex onto `DataReport` (repeating the same fix a third time for the next `Report` implementation), this centralizes serialization in `Backtest.worker`:

- `Backtest` now owns a `reportMu sync.Mutex` and locks around every call into `report.AssetBegin` / `report.Write` / `report.AssetEnd`.
- `Report`'s doc comment now states the contract: implementations don't need their own synchronization, since `Backtest` serializes calls across workers.
- `HTMLReport`'s now-redundant `mu sync.Mutex` is removed, since `Backtest` already guarantees serialized access.
- `report_factory.go`'s `reportBuilders` map (flagged as a lower-stakes instance of the same smell) is now guarded by a `sync.RWMutex`.

## Testing

- Added `TestBacktestAllAssetsAndStrategiesWithDataReport`, mirroring the existing `HTMLReport` `Workers = 16` test but for `DataReport` — this is the exact case that was previously untested.
- `go test -race ./backtest/...` and `go test ./...` pass.
- `go build ./...`, `go vet ./...`, `gofmt -l backtest/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)