### PR TITLE
Fix data race on Sync.hasErrors in asset/sync.go

### DIFF
--- a/asset/sync.go
+++ b/asset/sync.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cinar/indicator/v2/helper"
@@ -63,7 +64,7 @@ func (s *Sync) Run(source, target Repository, defaultStartDate time.Time) error 
 	s.Logger.Info("Start syncing.", "assets", len(s.Assets))
 	jobs := helper.SliceToChan(s.Assets)
 
-	hasErrors := false
+	var hasErrors atomic.Bool
 	wg := &sync.WaitGroup{}
 
 	for i := 0; i < s.Workers; i++ {
@@ -85,14 +86,14 @@ func (s *Sync) Run(source, target Repository, defaultStartDate time.Time) error 
 				snapshots, err := source.GetSince(name, lastDate)
 				if err != nil {
 					s.Logger.Error("GetSince failed.", "asset", name, "error", err)
-					hasErrors = true
+					hasErrors.Store(true)
 					continue
 				}
 
 				err = target.Append(name, snapshots)
 				if err != nil {
 					s.Logger.Error("Append failed.", "asset", name, "error", err)
-					hasErrors = true
+					hasErrors.Store(true)
 					continue
 				}
 
@@ -103,7 +104,7 @@ func (s *Sync) Run(source, target Repository, defaultStartDate time.Time) error 
 
 	wg.Wait()
 
-	if hasErrors {
+	if hasErrors.Load() {
 		return errors.New("has errors")
 	}
 

--- a/asset/sync_test.go
+++ b/asset/sync_test.go
@@ -128,6 +128,41 @@ func TestSyncFailingTargetAssets(t *testing.T) {
 	}
 }
 
+func TestSyncFailingTargetAppendMultiWorker(t *testing.T) {
+	assetNames := []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+
+	source := &MockRepository{
+		GetSinceFunc: func(_ string, _ time.Time) (<-chan *asset.Snapshot, error) {
+			return helper.SliceToChan([]*asset.Snapshot{}), nil
+		},
+	}
+
+	target := &MockRepository{
+		AssetsFunc: func() ([]string, error) {
+			return assetNames, nil
+		},
+
+		LastDateFunc: func(_ string) (time.Time, error) {
+			return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), nil
+		},
+
+		AppendFunc: func(_ string, _ <-chan *asset.Snapshot) error {
+			return errors.New("append error")
+		},
+	}
+
+	defaultStartDate := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	sync := asset.NewSync()
+	sync.Workers = 4
+	sync.Delay = 0
+
+	err := sync.Run(source, target, defaultStartDate)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestSyncFailingTargetAppend(t *testing.T) {
 	source := &MockRepository{
 		GetSinceFunc: func(_ string, _ time.Time) (<-chan *asset.Snapshot, error) {


### PR DESCRIPTION
## Summary
- `Sync.Run` wrote to a plain `bool` (`hasErrors`) from up to `s.Workers` goroutines with no synchronization — a data race, same bug class as the `DataReport` concurrent map write fixed in #401.
- Switched `hasErrors` to `atomic.Bool`.
- Added `TestSyncFailingTargetAppendMultiWorker`, which runs `Sync.Run` with `Workers = 4` and an erroring `Append`, so `go test -race` catches this class of regression going forward (the existing suite only ever ran `Sync.Run` with `Workers = 1`).

Verified the new test reproduces the race under `-race` against the pre-fix code, and passes clean with the fix.

Fixes #402

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] Confirmed `TestSyncFailingTargetAppendMultiWorker` fails with `WARNING: DATA RACE` against the pre-fix `bool`, and passes with `atomic.Bool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)