### PR TITLE
Fix SQLRepository.Append and GetSince silently dropping errors

### DIFF
--- a/asset/sql_repository.go
+++ b/asset/sql_repository.go
@@ -6,6 +6,7 @@ package asset
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -139,9 +140,14 @@ func (s *SQLRepository) GetSince(name string, date time.Time) (<-chan *Snapshot,
 			)
 			if err != nil {
 				log.Printf("unable to scan row: %v", err)
+				continue
 			}
 
 			snapshots <- snapshot
+		}
+
+		if err := rows.Err(); err != nil {
+			log.Printf("unable to iterate rows: %v", err)
 		}
 	}()
 
@@ -168,25 +174,25 @@ func (s *SQLRepository) LastDate(name string) (time.Time, error) {
 
 // Append adds the given snapshots to the asset with the given name.
 func (s *SQLRepository) Append(name string, snapshots <-chan *Snapshot) error {
-	go func() {
-		for snapshot := range snapshots {
-			_, err := s.appendQuery.Exec(
-				name,
-				snapshot.Date,
-				snapshot.Open,
-				snapshot.High,
-				snapshot.Low,
-				snapshot.Close,
-				snapshot.Volume,
-			)
+	var appendErrors []error
 
-			if err != nil {
-				log.Printf("unable to append snapshot: %v", err)
-			}
+	for snapshot := range snapshots {
+		_, err := s.appendQuery.Exec(
+			name,
+			snapshot.Date,
+			snapshot.Open,
+			snapshot.High,
+			snapshot.Low,
+			snapshot.Close,
+			snapshot.Volume,
+		)
+
+		if err != nil {
+			appendErrors = append(appendErrors, fmt.Errorf("unable to append snapshot: %w", err))
 		}
-	}()
+	}
 
-	return nil
+	return errors.Join(appendErrors...)
 }
 
 // Drop drops the snapshots table.

--- a/asset/sql_repository_test.go
+++ b/asset/sql_repository_test.go
@@ -7,6 +7,7 @@ package asset_test
 import (
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"io"
 	"testing"
 
@@ -60,8 +61,38 @@ func (r *mockRepoRows) Next(dest []driver.Value) error {
 	return nil
 }
 
+type mockRepoStmtAppendErr struct{}
+
+func (s *mockRepoStmtAppendErr) Close() error  { return nil }
+func (s *mockRepoStmtAppendErr) NumInput() int { return -1 }
+func (s *mockRepoStmtAppendErr) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, errors.New("insert failed")
+}
+func (s *mockRepoStmtAppendErr) Query(args []driver.Value) (driver.Rows, error) {
+	return &mockRepoRows{}, nil
+}
+
+type mockRepoConnAppendErr struct{}
+
+func (c *mockRepoConnAppendErr) Prepare(query string) (driver.Stmt, error) {
+	if query == "APPEND" {
+		return &mockRepoStmtAppendErr{}, nil
+	}
+
+	return &mockRepoStmt{}, nil
+}
+func (c *mockRepoConnAppendErr) Close() error              { return nil }
+func (c *mockRepoConnAppendErr) Begin() (driver.Tx, error) { return nil, nil }
+
+type mockRepoDriverAppendErr struct{}
+
+func (d *mockRepoDriverAppendErr) Open(name string) (driver.Conn, error) {
+	return &mockRepoConnAppendErr{}, nil
+}
+
 func init() {
 	sql.Register("mockrepo", &mockRepoDriver{})
+	sql.Register("mockrepoappenderr", &mockRepoDriverAppendErr{})
 }
 
 func TestSQLRepository(t *testing.T) {
@@ -101,5 +132,49 @@ func TestSQLRepository(t *testing.T) {
 	err = repo.Drop()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSQLRepositoryGetSinceSkipsScanErrors(t *testing.T) {
+	dialect := &mockDialect{}
+	repo, err := asset.NewSQLRepository("mockrepo", "db", dialect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repo.Close()
+
+	// mockRepoRows only provides a single column, so scanning it into
+	// a Snapshot's six fields fails. That row must be skipped rather
+	// than forwarded downstream as a zero-value Snapshot.
+	snapshots, err := repo.Get("TEST")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	for range snapshots {
+		count++
+	}
+
+	if count != 0 {
+		t.Fatalf("expected 0 snapshots, got %d", count)
+	}
+}
+
+func TestSQLRepositoryAppendReturnsError(t *testing.T) {
+	dialect := &mockDialect{}
+	repo, err := asset.NewSQLRepository("mockrepoappenderr", "db", dialect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repo.Close()
+
+	snapshots := make(chan *asset.Snapshot, 1)
+	snapshots <- &asset.Snapshot{}
+	close(snapshots)
+
+	err = repo.Append("TEST", snapshots)
+	if err == nil {
+		t.Fatal("expected error from Append, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #404.

- `Append` spawned a goroutine and returned `nil` before any row was written, so `Exec` errors only ever reached `log.Printf` and never the caller. `InMemoryRepository` and `FileSystemRepository` are both synchronous, and `asset/sync.go`'s retry logic reads the returned error from `Append` — for the SQL backend that error never arrived. Made `Append` synchronous; it now drains the channel and returns the joined `Exec` errors (or `nil`).
- `GetSince` forwarded a zero-value `Snapshot` downstream even when `Scan` failed on that row, turning a scan error into silently bogus data. It now skips the row on scan failure, and checks `rows.Err()` after the loop so a connection that dies mid-iteration doesn't look like a clean end-of-results.

## Test plan

- [x] `go build ./...`
- [x] `go test ./asset/... -race -v -run TestSQLRepository` — added `TestSQLRepositoryAppendReturnsError` (Append now surfaces Exec errors) and `TestSQLRepositoryGetSinceSkipsScanErrors` (scan-failed rows are no longer forwarded)
- [x] `go test ./... -race` — full suite passes
- [x] `gofmt -l .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)