### PR TITLE
Fix RSI/MFI-family integer divide-by-zero panic

### DIFF
--- a/momentum/README.md
+++ b/momentum/README.md
@@ -74,7 +74,7 @@ The information provided on this project is strictly for informational purposes 
   - [func \(ibs \*InternalBarStrength\[T\]\) IdlePeriod\(\) int](<#InternalBarStrength[T].IdlePeriod>)
   - [func \(ibs \*InternalBarStrength\[T\]\) String\(\) string](<#InternalBarStrength[T].String>)
 - [type Ppo](<#Ppo>)
-  - [func NewPpo\[T helper.Number\]\(\) \*Ppo\[T\]](<#NewPpo>)
+  - [func NewPpo\[T helper.Float\]\(\) \*Ppo\[T\]](<#NewPpo>)
   - [func \(p \*Ppo\[T\]\) Compute\(closings \<\-chan T\) \(\<\-chan T, \<\-chan T, \<\-chan T\)](<#Ppo[T].Compute>)
   - [func \(p \*Ppo\[T\]\) ComputeWithContext\(ctx context.Context, closings \<\-chan T\) \(\<\-chan T, \<\-chan T, \<\-chan T\)](<#Ppo[T].ComputeWithContext>)
   - [func \(p \*Ppo\[T\]\) IdlePeriod\(\) int](<#Ppo[T].IdlePeriod>)
@@ -83,7 +83,7 @@ The information provided on this project is strictly for informational purposes 
   - [func \(p \*PringsSpecialK\[T\]\) Compute\(closings \<\-chan T\) \<\-chan T](<#PringsSpecialK[T].Compute>)
   - [func \(p \*PringsSpecialK\[T\]\) ComputeWithContext\(ctx context.Context, closings \<\-chan T\) \<\-chan T](<#PringsSpecialK[T].ComputeWithContext>)
 - [type Pvo](<#Pvo>)
-  - [func NewPvo\[T helper.Number\]\(\) \*Pvo\[T\]](<#NewPvo>)
+  - [func NewPvo\[T helper.Float\]\(\) \*Pvo\[T\]](<#NewPvo>)
   - [func \(p \*Pvo\[T\]\) Compute\(volumes \<\-chan T\) \(\<\-chan T, \<\-chan T, \<\-chan T\)](<#Pvo[T].Compute>)
   - [func \(p \*Pvo\[T\]\) ComputeWithContext\(ctx context.Context, volumes \<\-chan T\) \(\<\-chan T, \<\-chan T, \<\-chan T\)](<#Pvo[T].ComputeWithContext>)
   - [func \(p \*Pvo\[T\]\) IdlePeriod\(\) int](<#Pvo[T].IdlePeriod>)
@@ -93,8 +93,8 @@ The information provided on this project is strictly for informational purposes 
   - [func \(q \*Qstick\[T\]\) ComputeWithContext\(ctx context.Context, openings, closings \<\-chan T\) \<\-chan T](<#Qstick[T].ComputeWithContext>)
   - [func \(q \*Qstick\[T\]\) IdlePeriod\(\) int](<#Qstick[T].IdlePeriod>)
 - [type Rsi](<#Rsi>)
-  - [func NewRsi\[T helper.Number\]\(\) \*Rsi\[T\]](<#NewRsi>)
-  - [func NewRsiWithPeriod\[T helper.Number\]\(period int\) \*Rsi\[T\]](<#NewRsiWithPeriod>)
+  - [func NewRsi\[T helper.Float\]\(\) \*Rsi\[T\]](<#NewRsi>)
+  - [func NewRsiWithPeriod\[T helper.Float\]\(period int\) \*Rsi\[T\]](<#NewRsiWithPeriod>)
   - [func \(r \*Rsi\[T\]\) Compute\(closings \<\-chan T\) \<\-chan T](<#Rsi[T].Compute>)
   - [func \(r \*Rsi\[T\]\) ComputeWithContext\(ctx context.Context, closings \<\-chan T\) \<\-chan T](<#Rsi[T].ComputeWithContext>)
   - [func \(r \*Rsi\[T\]\) IdlePeriod\(\) int](<#Rsi[T].IdlePeriod>)
@@ -110,8 +110,8 @@ The information provided on this project is strictly for informational purposes 
   - [func \(s \*StochasticOscillator\[T\]\) ComputeWithContext\(ctx context.Context, highs, lows, closings \<\-chan T\) \(\<\-chan T, \<\-chan T\)](<#StochasticOscillator[T].ComputeWithContext>)
   - [func \(s \*StochasticOscillator\[T\]\) IdlePeriod\(\) int](<#StochasticOscillator[T].IdlePeriod>)
 - [type StochasticRsi](<#StochasticRsi>)
-  - [func NewStochasticRsi\[T helper.Number\]\(\) \*StochasticRsi\[T\]](<#NewStochasticRsi>)
-  - [func NewStochasticRsiWithPeriod\[T helper.Number\]\(period int\) \*StochasticRsi\[T\]](<#NewStochasticRsiWithPeriod>)
+  - [func NewStochasticRsi\[T helper.Float\]\(\) \*StochasticRsi\[T\]](<#NewStochasticRsi>)
+  - [func NewStochasticRsiWithPeriod\[T helper.Float\]\(period int\) \*StochasticRsi\[T\]](<#NewStochasticRsiWithPeriod>)
   - [func \(s \*StochasticRsi\[T\]\) Compute\(closings \<\-chan T\) \<\-chan T](<#StochasticRsi[T].Compute>)
   - [func \(s \*StochasticRsi\[T\]\) ComputeWithContext\(ctx context.Context, closings \<\-chan T\) \<\-chan T](<#StochasticRsi[T].ComputeWithContext>)
   - [func \(s \*StochasticRsi\[T\]\) IdlePeriod\(\) int](<#StochasticRsi[T].IdlePeriod>)
@@ -133,7 +133,7 @@ The information provided on this project is strictly for informational purposes 
   - [func \(u \*UltimateOscillator\[T\]\) IdlePeriod\(\) int](<#UltimateOscillator[T].IdlePeriod>)
   - [func \(u \*UltimateOscillator\[T\]\) String\(\) string](<#UltimateOscillator[T].String>)
 - [type WilliamsR](<#WilliamsR>)
-  - [func NewWilliamsR\[T helper.Number\]\(\) \*WilliamsR\[T\]](<#NewWilliamsR>)
+  - [func NewWilliamsR\[T helper.Float\]\(\) \*WilliamsR\[T\]](<#NewWilliamsR>)
   - [func \(w \*WilliamsR\[T\]\) Compute\(highs, lows, closings \<\-chan T\) \<\-chan T](<#WilliamsR[T].Compute>)
   - [func \(w \*WilliamsR\[T\]\) ComputeWithContext\(ctx context.Context, highs, lows, closings \<\-chan T\) \<\-chan T](<#WilliamsR[T].ComputeWithContext>)
   - [func \(w \*WilliamsR\[T\]\) IdlePeriod\(\) int](<#WilliamsR[T].IdlePeriod>)
@@ -998,7 +998,7 @@ p, s, h := ppo.Compute(closings)
 ```
 
 ```go
-type Ppo[T helper.Number] struct {
+type Ppo[T helper.Float] struct {
     // ShortEma is the short EMA instance.
     ShortEma *trend.Ema[T]
 
@@ -1014,7 +1014,7 @@ type Ppo[T helper.Number] struct {
 ### func [NewPpo](<https://github.com/cinar/indicator/blob/master/momentum/ppo.go#L49>)
 
 ```go
-func NewPpo[T helper.Number]() *Ppo[T]
+func NewPpo[T helper.Float]() *Ppo[T]
 ```
 
 NewPpo function initializes a new Percentage Price Oscillator instance.
@@ -1131,7 +1131,7 @@ p, s, h := pvo.Compute(volumes)
 ```
 
 ```go
-type Pvo[T helper.Number] struct {
+type Pvo[T helper.Float] struct {
     // ShortEma is the short EMA instance.
     ShortEma *trend.Ema[T]
 
@@ -1147,7 +1147,7 @@ type Pvo[T helper.Number] struct {
 ### func [NewPvo](<https://github.com/cinar/indicator/blob/master/momentum/pvo.go#L49>)
 
 ```go
-func NewPvo[T helper.Number]() *Pvo[T]
+func NewPvo[T helper.Float]() *Pvo[T]
 ```
 
 NewPvo function initializes a new Percentage Volume Oscillator instance.
@@ -1263,7 +1263,7 @@ result := rsi.Compute(closings)
 ```
 
 ```go
-type Rsi[T helper.Number] struct {
+type Rsi[T helper.Float] struct {
     // Rma is the RMA instance.
     Rma *trend.Rma[T]
 }
@@ -1273,7 +1273,7 @@ type Rsi[T helper.Number] struct {
 ### func [NewRsi](<https://github.com/cinar/indicator/blob/master/momentum/rsi.go#L35>)
 
 ```go
-func NewRsi[T helper.Number]() *Rsi[T]
+func NewRsi[T helper.Float]() *Rsi[T]
 ```
 
 NewRsi function initializes a new Relative Strength Index instance with the default parameters.
@@ -1282,7 +1282,7 @@ NewRsi function initializes a new Relative Strength Index instance with the defa
 ### func [NewRsiWithPeriod](<https://github.com/cinar/indicator/blob/master/momentum/rsi.go#L40>)
 
 ```go
-func NewRsiWithPeriod[T helper.Number](period int) *Rsi[T]
+func NewRsiWithPeriod[T helper.Float](period int) *Rsi[T]
 ```
 
 NewRsiWithPeriod function initializes a new Relative Strength Index instance with the given period.
@@ -1483,7 +1483,7 @@ result := stochasticRsi.Compute(closings)
 ```
 
 ```go
-type StochasticRsi[T helper.Number] struct {
+type StochasticRsi[T helper.Float] struct {
     // Rsi is that RSI instance.
     Rsi *Rsi[T]
 
@@ -1499,7 +1499,7 @@ type StochasticRsi[T helper.Number] struct {
 ### func [NewStochasticRsi](<https://github.com/cinar/indicator/blob/master/momentum/stochastic_rsi.go#L43>)
 
 ```go
-func NewStochasticRsi[T helper.Number]() *StochasticRsi[T]
+func NewStochasticRsi[T helper.Float]() *StochasticRsi[T]
 ```
 
 NewStochasticRsi function initializes a new Storchastic RSI instance with the default parameters.
@@ -1508,7 +1508,7 @@ NewStochasticRsi function initializes a new Storchastic RSI instance with the de
 ### func [NewStochasticRsiWithPeriod](<https://github.com/cinar/indicator/blob/master/momentum/stochastic_rsi.go#L48>)
 
 ```go
-func NewStochasticRsiWithPeriod[T helper.Number](period int) *StochasticRsi[T]
+func NewStochasticRsiWithPeriod[T helper.Float](period int) *StochasticRsi[T]
 ```
 
 NewStochasticRsiWithPeriod function initializes a new Stochastic RSI instance with the given period.
@@ -1772,7 +1772,7 @@ values := wr.Compute(highs, lows, closings)
 ```
 
 ```go
-type WilliamsR[T helper.Number] struct {
+type WilliamsR[T helper.Float] struct {
     // Max is the Moving Max instance.
     Max *trend.MovingMax[T]
 
@@ -1785,7 +1785,7 @@ type WilliamsR[T helper.Number] struct {
 ### func [NewWilliamsR](<https://github.com/cinar/indicator/blob/master/momentum/williams_r.go#L40>)
 
 ```go
-func NewWilliamsR[T helper.Number]() *WilliamsR[T]
+func NewWilliamsR[T helper.Float]() *WilliamsR[T]
 ```
 
 NewWilliamsR function initializes a new Williams R instance.

--- a/momentum/ppo.go
+++ b/momentum/ppo.go
@@ -34,7 +34,7 @@ const (
 //
 //	ppo := momentum.Ppo[float64]()
 //	p, s, h := ppo.Compute(closings)
-type Ppo[T helper.Number] struct {
+type Ppo[T helper.Float] struct {
 	// ShortEma is the short EMA instance.
 	ShortEma *trend.Ema[T]
 
@@ -46,7 +46,7 @@ type Ppo[T helper.Number] struct {
 }
 
 // NewPpo function initializes a new Percentage Price Oscillator instance.
-func NewPpo[T helper.Number]() *Ppo[T] {
+func NewPpo[T helper.Float]() *Ppo[T] {
 	return &Ppo[T]{
 		ShortEma:  trend.NewEmaWithPeriod[T](DefaultPpoShortPeriod),
 		LongEma:   trend.NewEmaWithPeriod[T](DefaultPpoLongPeriod),

--- a/momentum/pvo.go
+++ b/momentum/pvo.go
@@ -34,7 +34,7 @@ const (
 //
 //	pvo := momentum.Pvo[float64]()
 //	p, s, h := pvo.Compute(volumes)
-type Pvo[T helper.Number] struct {
+type Pvo[T helper.Float] struct {
 	// ShortEma is the short EMA instance.
 	ShortEma *trend.Ema[T]
 
@@ -46,7 +46,7 @@ type Pvo[T helper.Number] struct {
 }
 
 // NewPvo function initializes a new Percentage Volume Oscillator instance.
-func NewPvo[T helper.Number]() *Pvo[T] {
+func NewPvo[T helper.Float]() *Pvo[T] {
 	return &Pvo[T]{
 		ShortEma:  trend.NewEmaWithPeriod[T](DefaultPvoShortPeriod),
 		LongEma:   trend.NewEmaWithPeriod[T](DefaultPvoLongPeriod),

--- a/momentum/rsi.go
+++ b/momentum/rsi.go
@@ -26,18 +26,18 @@ const (
 //
 //	rsi := momentum.NewRsi[float64]()
 //	result := rsi.Compute(closings)
-type Rsi[T helper.Number] struct {
+type Rsi[T helper.Float] struct {
 	// Rma is the RMA instance.
 	Rma *trend.Rma[T]
 }
 
 // NewRsi function initializes a new Relative Strength Index instance with the default parameters.
-func NewRsi[T helper.Number]() *Rsi[T] {
+func NewRsi[T helper.Float]() *Rsi[T] {
 	return NewRsiWithPeriod[T](DefaultRsiPeriod)
 }
 
 // NewRsiWithPeriod function initializes a new Relative Strength Index instance with the given period.
-func NewRsiWithPeriod[T helper.Number](period int) *Rsi[T] {
+func NewRsiWithPeriod[T helper.Float](period int) *Rsi[T] {
 	return &Rsi[T]{
 		Rma: trend.NewRmaWithPeriod[T](period),
 	}

--- a/momentum/stochastic_rsi.go
+++ b/momentum/stochastic_rsi.go
@@ -28,7 +28,7 @@ const (
 //
 //	stochasticRsi := momentum.NewStochasticRsi[float64]()
 //	result := stochasticRsi.Compute(closings)
-type StochasticRsi[T helper.Number] struct {
+type StochasticRsi[T helper.Float] struct {
 	// Rsi is that RSI instance.
 	Rsi *Rsi[T]
 
@@ -40,12 +40,12 @@ type StochasticRsi[T helper.Number] struct {
 }
 
 // NewStochasticRsi function initializes a new Storchastic RSI instance with the default parameters.
-func NewStochasticRsi[T helper.Number]() *StochasticRsi[T] {
+func NewStochasticRsi[T helper.Float]() *StochasticRsi[T] {
 	return NewStochasticRsiWithPeriod[T](DefaultStochasticRsiPeriod)
 }
 
 // NewStochasticRsiWithPeriod function initializes a new Stochastic RSI instance with the given period.
-func NewStochasticRsiWithPeriod[T helper.Number](period int) *StochasticRsi[T] {
+func NewStochasticRsiWithPeriod[T helper.Float](period int) *StochasticRsi[T] {
 	return &StochasticRsi[T]{
 		Rsi: NewRsiWithPeriod[T](period),
 		Min: trend.NewMovingMinWithPeriod[T](period),

--- a/momentum/williams_r.go
+++ b/momentum/williams_r.go
@@ -28,7 +28,7 @@ const (
 //
 //	wr := momentum.WilliamsR[float64]()
 //	values := wr.Compute(highs, lows, closings)
-type WilliamsR[T helper.Number] struct {
+type WilliamsR[T helper.Float] struct {
 	// Max is the Moving Max instance.
 	Max *trend.MovingMax[T]
 
@@ -37,7 +37,7 @@ type WilliamsR[T helper.Number] struct {
 }
 
 // NewWilliamsR function initializes a new Williams R instance.
-func NewWilliamsR[T helper.Number]() *WilliamsR[T] {
+func NewWilliamsR[T helper.Float]() *WilliamsR[T] {
 	return &WilliamsR[T]{
 		Max: trend.NewMovingMaxWithPeriod[T](DefaultWilliamsRPeriod),
 		Min: trend.NewMovingMinWithPeriod[T](DefaultWilliamsRPeriod),

--- a/volume/README.md
+++ b/volume/README.md
@@ -54,8 +54,8 @@ The information provided on this project is strictly for informational purposes 
   - [func \(k \*Kvo\[T\]\) ComputeWithContext\(ctx context.Context, highs, lows, volumes \<\-chan T\) \(\<\-chan T, \<\-chan T\)](<#Kvo[T].ComputeWithContext>)
   - [func \(k \*Kvo\[T\]\) IdlePeriod\(\) int](<#Kvo[T].IdlePeriod>)
 - [type Mfi](<#Mfi>)
-  - [func NewMfi\[T helper.Number\]\(\) \*Mfi\[T\]](<#NewMfi>)
-  - [func NewMfiWithPeriod\[T helper.Number\]\(period int\) \*Mfi\[T\]](<#NewMfiWithPeriod>)
+  - [func NewMfi\[T helper.Float\]\(\) \*Mfi\[T\]](<#NewMfi>)
+  - [func NewMfiWithPeriod\[T helper.Float\]\(period int\) \*Mfi\[T\]](<#NewMfiWithPeriod>)
   - [func \(m \*Mfi\[T\]\) Compute\(highs, lows, closings, volumes \<\-chan T\) \<\-chan T](<#Mfi[T].Compute>)
   - [func \(m \*Mfi\[T\]\) ComputeWithContext\(ctx context.Context, highs, lows, closings, volumes \<\-chan T\) \<\-chan T](<#Mfi[T].ComputeWithContext>)
   - [func \(m \*Mfi\[T\]\) IdlePeriod\(\) int](<#Mfi[T].IdlePeriod>)
@@ -535,7 +535,7 @@ result := mfi.Compute(highs, lows, closings, volumes)
 ```
 
 ```go
-type Mfi[T helper.Number] struct {
+type Mfi[T helper.Float] struct {
     // TypicalPrice is the Typical Price instance.
     TypicalPrice *trend.TypicalPrice[T]
 
@@ -548,7 +548,7 @@ type Mfi[T helper.Number] struct {
 ### func [NewMfi](<https://github.com/cinar/indicator/blob/master/volume/mfi.go#L40>)
 
 ```go
-func NewMfi[T helper.Number]() *Mfi[T]
+func NewMfi[T helper.Float]() *Mfi[T]
 ```
 
 NewMfi function initializes a new MFI instance with the default parameters.
@@ -557,7 +557,7 @@ NewMfi function initializes a new MFI instance with the default parameters.
 ### func [NewMfiWithPeriod](<https://github.com/cinar/indicator/blob/master/volume/mfi.go#L45>)
 
 ```go
-func NewMfiWithPeriod[T helper.Number](period int) *Mfi[T]
+func NewMfiWithPeriod[T helper.Float](period int) *Mfi[T]
 ```
 
 NewMfiWithPeriod function initializes a new MFI instance with the given period.

--- a/volume/mfi.go
+++ b/volume/mfi.go
@@ -28,7 +28,7 @@ const (
 //
 //	mfi := volume.NewMfi[float64]()
 //	result := mfi.Compute(highs, lows, closings, volumes)
-type Mfi[T helper.Number] struct {
+type Mfi[T helper.Float] struct {
 	// TypicalPrice is the Typical Price instance.
 	TypicalPrice *trend.TypicalPrice[T]
 
@@ -37,12 +37,12 @@ type Mfi[T helper.Number] struct {
 }
 
 // NewMfi function initializes a new MFI instance with the default parameters.
-func NewMfi[T helper.Number]() *Mfi[T] {
+func NewMfi[T helper.Float]() *Mfi[T] {
 	return NewMfiWithPeriod[T](DefaultMfiPeriod)
 }
 
 // NewMfiWithPeriod function initializes a new MFI instance with the given period.
-func NewMfiWithPeriod[T helper.Number](period int) *Mfi[T] {
+func NewMfiWithPeriod[T helper.Float](period int) *Mfi[T] {
 	return &Mfi[T]{
 		TypicalPrice: trend.NewTypicalPrice[T](),
 		Sum:          trend.NewMovingSumWithPeriod[T](period),


### PR DESCRIPTION
## Summary

- `Rsi`, `Mfi`, `StochasticRsi`, `WilliamsR`, `Ppo`, and `Pvo` were generic over `helper.Number`, which includes integer types. Their computation chains call `helper.DivideWithContext`, dividing by values (average loss, negative money flow, etc.) that are legitimately zero on flat or quiet markets.
- Over `float64` this degrades gracefully to `+Inf` (arguably correct "RSI is 100" behavior). Over an integer type it panics with an integer divide-by-zero, crashing the calling goroutine.
- The test suite only ever exercised these over `float64`, so the bug was invisible in CI.

## Fix

Narrow all six types' generic parameter from `T helper.Number` to `T helper.Float`, matching the precedent already set by `ConnorsRsi`. Every existing call site and test already instantiates these with `float64`, so this is non-breaking — the invalid instantiation is now a compile-time error instead of a runtime panic.

Regenerated the `momentum/README.md` and `volume/README.md` doc sections affected by these signatures (`gomarkdoc`) — I limited the diff to just those lines since a full `docs` task run produced unrelated churn across every other README.

Fixes #406

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`