### PR TITLE
Fix Aroon goroutine leak on context cancellation

### DIFF
--- a/helper/README.md
+++ b/helper/README.md
@@ -95,7 +95,9 @@ The information provided on this project is strictly for informational purposes 
 - [func MapWithPrevious\[F, T any\]\(c \<\-chan F, f func\(T, F\) T, previous T\) \<\-chan T](<#MapWithPrevious>)
 - [func MapWithPreviousWithContext\[F, T any\]\(ctx context.Context, c \<\-chan F, f func\(T, F\) T, previous T\) \<\-chan T](<#MapWithPreviousWithContext>)
 - [func MaxSince\[T Number\]\(c \<\-chan T, w int\) \<\-chan T](<#MaxSince>)
+- [func MaxSinceWithContext\[T Number\]\(ctx context.Context, c \<\-chan T, w int\) \<\-chan T](<#MaxSinceWithContext>)
 - [func MinSince\[T Number\]\(c \<\-chan T, w int\) \<\-chan T](<#MinSince>)
+- [func MinSinceWithContext\[T Number\]\(ctx context.Context, c \<\-chan T, w int\) \<\-chan T](<#MinSinceWithContext>)
 - [func Multiply\[T Number\]\(ac, bc \<\-chan T\) \<\-chan T](<#Multiply>)
 - [func MultiplyBy\[T Number\]\(c \<\-chan T, m T\) \<\-chan T](<#MultiplyBy>)
 - [func MultiplyByWithContext\[T Number\]\(ctx context.Context, c \<\-chan T, m T\) \<\-chan T](<#MultiplyByWithContext>)
@@ -1028,22 +1030,44 @@ func MapWithPreviousWithContext[F, T any](ctx context.Context, c <-chan F, f fun
 MapWithPreviousWithContext applies a transformation function to each element in an input channel, creating a new channel with the transformed values, supporting context cancellation.
 
 <a name="MaxSince"></a>
-## func [MaxSince](<https://github.com/cinar/indicator/blob/master/helper/max_since.go#L14>)
+## func [MaxSince](<https://github.com/cinar/indicator/blob/master/helper/max_since.go#L37>)
 
 ```go
 func MaxSince[T Number](c <-chan T, w int) <-chan T
 ```
 
-MaxSince returns a channel of T indicating since when \(number of previous values\) the respective value was the maximum within the window of size w.
+MaxSince wraps MaxSinceWithContext for backwards compatibility.
+
+Deprecated: Use MaxSinceWithContext instead.
+
+<a name="MaxSinceWithContext"></a>
+## func [MaxSinceWithContext](<https://github.com/cinar/indicator/blob/master/helper/max_since.go#L15>)
+
+```go
+func MaxSinceWithContext[T Number](ctx context.Context, c <-chan T, w int) <-chan T
+```
+
+MaxSinceWithContext returns a channel of T indicating since when \(number of previous values\) the respective value was the maximum within the window of size w.
 
 <a name="MinSince"></a>
-## func [MinSince](<https://github.com/cinar/indicator/blob/master/helper/min_since.go#L13>)
+## func [MinSince](<https://github.com/cinar/indicator/blob/master/helper/min_since.go#L36>)
 
 ```go
 func MinSince[T Number](c <-chan T, w int) <-chan T
 ```
 
-MinSince returns a channel of T indicating since when \(number of previous values\) the respective value was the minimum.
+MinSince wraps MinSinceWithContext for backwards compatibility.
+
+Deprecated: Use MinSinceWithContext instead.
+
+<a name="MinSinceWithContext"></a>
+## func [MinSinceWithContext](<https://github.com/cinar/indicator/blob/master/helper/min_since.go#L14>)
+
+```go
+func MinSinceWithContext[T Number](ctx context.Context, c <-chan T, w int) <-chan T
+```
+
+MinSinceWithContext returns a channel of T indicating since when \(number of previous values\) the respective value was the minimum.
 
 <a name="Multiply"></a>
 ## func [Multiply](<https://github.com/cinar/indicator/blob/master/helper/multiply.go#L33>)

--- a/helper/cancellation_test.go
+++ b/helper/cancellation_test.go
@@ -67,6 +67,25 @@ func TestCancellationWithApplyWindow(t *testing.T) {
 	}
 }
 
+func TestCancellationWithMaxSinceMinSince(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	input := make(chan int)
+
+	maxSince := helper.MaxSinceWithContext(ctx, input, 3)
+	minSince := helper.MinSinceWithContext(ctx, input, 3)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := <-maxSince; ok {
+		t.Fatal("MaxSince channel should be closed after cancellation")
+	}
+	if _, ok := <-minSince; ok {
+		t.Fatal("MinSince channel should be closed after cancellation")
+	}
+}
+
 func TestCancellationWithEchoSkip(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	input := make(chan int)

--- a/helper/max_since.go
+++ b/helper/max_since.go
@@ -5,14 +5,15 @@
 package helper
 
 import (
+	"context"
 	"slices"
 )
 
-// MaxSince returns a channel of T indicating since when
+// MaxSinceWithContext returns a channel of T indicating since when
 // (number of previous values) the respective value was the maximum
 // within the window of size w.
-func MaxSince[T Number](c <-chan T, w int) <-chan T {
-	return Window(c, func(w []T, i int) T {
+func MaxSinceWithContext[T Number](ctx context.Context, c <-chan T, w int) <-chan T {
+	return WindowWithContext(ctx, c, func(w []T, i int) T {
 		since := 0
 		found := false
 		m := slices.Max(w)
@@ -28,4 +29,11 @@ func MaxSince[T Number](c <-chan T, w int) <-chan T {
 		})
 		return T(since - 1)
 	}, w)
+}
+
+// MaxSince wraps MaxSinceWithContext for backwards compatibility.
+//
+// Deprecated: Use MaxSinceWithContext instead.
+func MaxSince[T Number](c <-chan T, w int) <-chan T {
+	return MaxSinceWithContext(context.Background(), c, w)
 }

--- a/helper/min_since.go
+++ b/helper/min_since.go
@@ -5,13 +5,14 @@
 package helper
 
 import (
+	"context"
 	"slices"
 )
 
-// MinSince returns a channel of T indicating since when
+// MinSinceWithContext returns a channel of T indicating since when
 // (number of previous values) the respective value was the minimum.
-func MinSince[T Number](c <-chan T, w int) <-chan T {
-	return Window(c, func(w []T, i int) T {
+func MinSinceWithContext[T Number](ctx context.Context, c <-chan T, w int) <-chan T {
+	return WindowWithContext(ctx, c, func(w []T, i int) T {
 		since := 0
 		found := false
 		m := slices.Min(w)
@@ -27,4 +28,11 @@ func MinSince[T Number](c <-chan T, w int) <-chan T {
 		})
 		return T(since - 1)
 	}, w)
+}
+
+// MinSince wraps MinSinceWithContext for backwards compatibility.
+//
+// Deprecated: Use MinSinceWithContext instead.
+func MinSince[T Number](c <-chan T, w int) <-chan T {
+	return MinSinceWithContext(context.Background(), c, w)
 }

--- a/trend/aroon.go
+++ b/trend/aroon.go
@@ -50,8 +50,8 @@ func (a *Aroon[T]) ComputeWithContext(ctx context.Context, high, low <-chan T) (
 	movingMax := NewMovingMaxWithPeriod[T](a.Period)
 	movingMin := NewMovingMinWithPeriod[T](a.Period)
 
-	sinceLastHigh := helper.MaxSince(movingMax.ComputeWithContext(ctx, high), a.Period)
-	sinceLastLow := helper.MinSince(movingMin.ComputeWithContext(ctx, low), a.Period)
+	sinceLastHigh := helper.MaxSinceWithContext(ctx, movingMax.ComputeWithContext(ctx, high), a.Period)
+	sinceLastLow := helper.MinSinceWithContext(ctx, movingMin.ComputeWithContext(ctx, low), a.Period)
 
 	// Aroon Up = ((25 - Period Since Last 25 Period High) / 25) * 100
 	aroonUp := helper.MultiplyByWithContext(ctx, sinceLastHigh, -1)

--- a/trend/aroon_test.go
+++ b/trend/aroon_test.go
@@ -5,7 +5,10 @@
 package trend_test
 
 import (
+	"context"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -87,6 +90,35 @@ func TestAroonCompareRust(t *testing.T) {
 	err := helper.CheckEquals(actualUp, expectedUp, actualDown, expectedDown)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAroonCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	high := make(chan float64)
+	low := make(chan float64)
+
+	aroon := trend.NewAroon[float64]()
+	up, down := aroon.ComputeWithContext(ctx, high, low)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	if _, ok := <-up; ok {
+		t.Fatal("Up channel should be closed after cancellation")
+	}
+	if _, ok := <-down; ok {
+		t.Fatal("Down channel should be closed after cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `trend.Aroon.ComputeWithContext` threads its `context.Context` through every stage of its pipeline except one: it called the plain `helper.MaxSince`/`helper.MinSince`, which have no `WithContext` variant and run internally on `context.Background()`.
- If the caller cancels `ctx` while a value is in flight, every downstream `WithContext` stage (the `MultiplyByWithContext`/`IncrementByWithContext`/... chain) exits immediately via its own `ctx.Done()` case and stops reading. `MaxSince`/`MinSince`'s goroutine has no live `ctx.Done()` case of its own (it's bound to `Background()`, whose `Done()` channel is `nil` and never fires), so it blocks forever trying to send to a receiver that will never read again — a leaked goroutine per cancelled `Aroon` computation.
- Harmless for a short CLI run, but a real problem for any long-running service built on this library (the direction the MCP server is already pushing this project).

## Fix

Added `MaxSinceWithContext`/`MinSinceWithContext` to `helper/`, following the existing `Highest`/`HighestWithContext` precedent (call `WindowWithContext(ctx, ...)` directly; keep the non-context variant as a deprecated wrapper). Updated `trend/aroon.go`'s `ComputeWithContext` to call the new `WithContext` variants with its own `ctx`.

I reproduced the leak directly before writing the fix: temporarily made `MaxSinceWithContext`/`MinSinceWithContext` ignore `ctx` (delegate to the old `Window`), ran the new cancellation test with `-race -timeout 5s`, and got goroutines permanently parked `[select]` at `window.go:32`. Restoring `WindowWithContext(ctx, ...)` fixes it.

Fixes #408

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no output)
- [x] `go test -race ./...`
- [x] Added `TestCancellationWithMaxSinceMinSince` (helper) and `TestAroonCancellation` (trend) — both verified to fail/hang against the pre-fix code, pass against the fix
- [x] Regenerated the `helper/README.md` doc section for `MaxSince`/`MinSince`/`MaxSinceWithContext`/`MinSinceWithContext` via `gomarkdoc`, limited to just those lines (a full `docs` run produces unrelated link-formatting churn across every README, same issue noted in #407)

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>