### PR TITLE
Fix consistency and doc drift across indicators

### DIFF
--- a/asset/sql_repository.go
+++ b/asset/sql_repository.go
@@ -8,7 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/cinar/indicator/v2/helper"
@@ -16,6 +16,9 @@ import (
 
 // SQLRepository provides a SQL backed storage facility for financial market data.
 type SQLRepository struct {
+	// Logger is the slog logger instance.
+	Logger *slog.Logger
+
 	// db is the database connection.
 	db *sql.DB
 
@@ -68,12 +71,13 @@ func NewSQLRepository(dbDriver, dbURL string, dialect SQLRepositoryDialect) (*SQ
 	}
 
 	repository := &SQLRepository{
-		db,
-		dialect,
-		assetQuery,
-		getSinceQuery,
-		lastDateQuery,
-		appendQuery,
+		Logger:        slog.Default(),
+		db:            db,
+		dialect:       dialect,
+		assetsQuery:   assetQuery,
+		getSinceQuery: getSinceQuery,
+		lastDateQuery: lastDateQuery,
+		appendQuery:   appendQuery,
 	}
 
 	return repository, nil
@@ -139,7 +143,7 @@ func (s *SQLRepository) GetSince(name string, date time.Time) (<-chan *Snapshot,
 				&snapshot.Volume,
 			)
 			if err != nil {
-				log.Printf("unable to scan row: %v", err)
+				s.Logger.Error("Unable to scan row.", "asset", name, "error", err)
 				continue
 			}
 
@@ -147,7 +151,7 @@ func (s *SQLRepository) GetSince(name string, date time.Time) (<-chan *Snapshot,
 		}
 
 		if err := rows.Err(); err != nil {
-			log.Printf("unable to iterate rows: %v", err)
+			s.Logger.Error("Unable to iterate rows.", "asset", name, "error", err)
 		}
 	}()
 

--- a/helper/sync.go
+++ b/helper/sync.go
@@ -6,7 +6,8 @@ package helper
 
 import "slices"
 
-// CommonPeriod calculates the smallest period at which all data channels can be synchronized
+// CommonPeriod calculates the largest period at which all data channels can be synchronized,
+// so that every channel has warmed up (skipped its own idle period) before values are compared.
 //
 // Example:
 //

--- a/momentum/prings_special_k.go
+++ b/momentum/prings_special_k.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2021-2026 Onur Cinar.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
 package momentum
 
 import (
@@ -11,6 +15,11 @@ import (
 // It composes multiple Rate-of-Change (ROC) series smoothed by Simple Moving Averages (SMA)
 // and outputs a weighted sum aligned to the slowest path so all terms are time-synchronized.
 // See Compute for the exact composition and weights.
+//
+// This constrains on helper.Float rather than the usual helper.Number: the
+// underlying Roc computation divides by an earlier value in the series, and
+// over integer types that division truncates badly enough to distort the
+// weighted sum, so integer support is intentionally not offered here.
 type PringsSpecialK[T helper.Float] struct {
 	Roc10  *trend.Roc[T]
 	Roc15  *trend.Roc[T]

--- a/trend/aroon.go
+++ b/trend/aroon.go
@@ -70,6 +70,11 @@ func (a *Aroon[T]) ComputeWithContext(ctx context.Context, high, low <-chan T) (
 	return aroonUp, aroonDown
 }
 
+// IdlePeriod is the initial period that Aroon won't yield any results.
+func (a *Aroon[T]) IdlePeriod() int {
+	return a.Period - 1
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/trend/aroon_test.go
+++ b/trend/aroon_test.go
@@ -35,8 +35,8 @@ func TestAroon(t *testing.T) {
 	expectedUp := helper.Map(inputs[2], func(row *AroonData) float64 { return row.Up })
 	expectedDown := helper.Map(inputs[3], func(row *AroonData) float64 { return row.Down })
 
-	expectedUp = helper.Skip(expectedUp, aroon.Period-1)
-	expectedDown = helper.Skip(expectedDown, aroon.Period-1)
+	expectedUp = helper.Skip(expectedUp, aroon.IdlePeriod())
+	expectedDown = helper.Skip(expectedDown, aroon.IdlePeriod())
 
 	actualUp, actualDown := aroon.Compute(high, low)
 
@@ -82,8 +82,8 @@ func TestAroonCompareRust(t *testing.T) {
 	expectedUp := helper.Map(inputs[2], func(row AroonData) float64 { return row.Up })
 	expectedDown := helper.Map(inputs[3], func(row AroonData) float64 { return row.Down })
 
-	expectedUp = helper.Skip(expectedUp, aroon.Period-1)
-	expectedDown = helper.Skip(expectedDown, aroon.Period-1)
+	expectedUp = helper.Skip(expectedUp, aroon.IdlePeriod())
+	expectedDown = helper.Skip(expectedDown, aroon.IdlePeriod())
 
 	actualUp, actualDown := aroon.Compute(high, low)
 
@@ -157,8 +157,8 @@ func TestAroonValidateDefinition(t *testing.T) {
 	expectedUp := helper.Map(inputs[2], func(row AroonData) float64 { return row.Up })
 	expectedDown := helper.Map(inputs[3], func(row AroonData) float64 { return row.Down })
 
-	expectedUp = helper.Skip(expectedUp, aroon.Period-1)
-	expectedDown = helper.Skip(expectedDown, aroon.Period-1)
+	expectedUp = helper.Skip(expectedUp, aroon.IdlePeriod())
+	expectedDown = helper.Skip(expectedDown, aroon.IdlePeriod())
 
 	actualUp, actualDown := aroon.Compute(high, low)
 

--- a/trend/bop.go
+++ b/trend/bop.go
@@ -31,6 +31,11 @@ func (i *Bop[T]) ComputeWithContext(ctx context.Context, opening, high, low, clo
 	return helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, closing, opening), helper.SubtractWithContext(ctx, high, low))
 }
 
+// IdlePeriod is the initial period that BOP won't yield any results.
+func (*Bop[T]) IdlePeriod() int {
+	return 0
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/trend/macd.go
+++ b/trend/macd.go
@@ -28,6 +28,9 @@ const (
 //	Signal = 9-Period EMA of MACD.
 //
 // Example:
+//
+//	macd := trend.NewMacd[float64]()
+//	macdLine, signal := macd.Compute(c)
 type Macd[T helper.Number] struct {
 	Ema1 *Ema[T]
 	Ema2 *Ema[T]

--- a/trend/typical_price.go
+++ b/trend/typical_price.go
@@ -31,6 +31,11 @@ func (i *TypicalPrice[T]) ComputeWithContext(ctx context.Context, high, low, clo
 	)
 }
 
+// IdlePeriod is the initial period that Typical Price won't yield any results.
+func (*TypicalPrice[T]) IdlePeriod() int {
+	return 0
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/volatility/bollinger_bands.go
+++ b/volatility/bollinger_bands.go
@@ -14,6 +14,9 @@ import (
 const (
 	// DefaultBollingerBandsPeriod is the default period for the Bollinger Bands.
 	DefaultBollingerBandsPeriod = 20
+
+	// DefaultBollingerBandsMultiplier is the default standard deviation multiplier for the Bollinger Bands.
+	DefaultBollingerBandsMultiplier = 2
 )
 
 // BollingerBands represents the configuration parameters for calculating the Bollinger Bands. It is a technical
@@ -21,8 +24,8 @@ const (
 // the upper band, the middle band, and the lower band.
 //
 //	Middle Band = 20-Period SMA.
-//	Upper Band = 20-Period SMA + 2 (20-Period Std)
-//	Lower Band = 20-Period SMA - 2 (20-Period Std)
+//	Upper Band = 20-Period SMA + Multiplier (20-Period Std)
+//	Lower Band = 20-Period SMA - Multiplier (20-Period Std)
 //
 // Example:
 //
@@ -31,6 +34,9 @@ const (
 type BollingerBands[T helper.Number] struct {
 	// Time period.
 	Period int
+
+	// Multiplier is the standard deviation multiplier.
+	Multiplier T
 }
 
 // NewBollingerBands function initializes a new Bollinger Bands instance with the default parameters.
@@ -41,7 +47,8 @@ func NewBollingerBands[T helper.Number]() *BollingerBands[T] {
 // NewBollingerBandsWithPeriod function initializes a new Bollinger Bands instance with the given period.
 func NewBollingerBandsWithPeriod[T helper.Number](period int) *BollingerBands[T] {
 	return &BollingerBands[T]{
-		Period: period,
+		Period:     period,
+		Multiplier: DefaultBollingerBandsMultiplier,
 	}
 }
 
@@ -56,7 +63,7 @@ func (b *BollingerBands[T]) ComputeWithContext(ctx context.Context, c <-chan T) 
 	)
 
 	std2s := helper.DuplicateWithContext(ctx, helper.MultiplyByWithContext(ctx, std.ComputeWithContext(ctx, cs[1]),
-		2,
+		b.Multiplier,
 	),
 		2,
 	)


### PR DESCRIPTION
Closes #412.

From Rob Pike's review (rob.md, section 6): a batch of small consistency and documentation fixes across the indicator packages. None of these are bugs on their own, but the drift erodes trust in the codebase's otherwise-consistent patterns.

- `IdlePeriod()` added to `trend/aroon.go`, `trend/bop.go`, `trend/typical_price.go`.
  - Verified `Aroon`'s idle period empirically against `testdata/aroon.csv`: it's `Period - 1`, not `2*(Period-1)` as a naive analogy to `Cci` (which explicitly re-skips after its second SMA) would suggest — `MaxSinceWithContext` doesn't drop values the way `MovingMax` does. Updated `aroon_test.go` to call `aroon.IdlePeriod()` instead of hardcoding `aroon.Period-1`, so this is now a regression test.
  - `Bop` and `TypicalPrice` are pure elementwise transforms (no windowing), so both return `0`.
  - **Not done:** `valuation/fv.go`, `valuation/pv.go`, `valuation/npv.go` are plain stateless functions with no struct or `Compute` method at all — the `NewXxx`/`ComputeWithContext`/`IdlePeriod` quintet doesn't apply to them, so I left them alone rather than force a pattern that doesn't fit.
- `momentum/prings_special_k.go`: added the standard license header (it was the only file missing it), and documented why `PringsSpecialK` constrains on `helper.Float` instead of the usual `helper.Number` — it holds `*trend.Roc[T]` fields, and `Roc`'s `(value-p)/p` would truncate badly over integers.
- `volatility/bollinger_bands.go`: exposed the standard-deviation multiplier as a `Multiplier` field (defaulting to `2` via `DefaultBollingerBandsMultiplier`) instead of a hardcoded literal, so callers can use 1.5/2.5 without forking.
- `trend/macd.go`: filled in the dangling empty `// Example:` doc comment.
- `helper/sync.go`: fixed `CommonPeriod`'s doc comment, which said it returns the "smallest" period when the code (correctly) returns `slices.Max`.
- `asset/sql_repository.go`: added an injectable `Logger *slog.Logger` field (defaulting to `slog.Default()`) and replaced the two `log.Printf` calls in `GetSince`, matching the pattern already used by `asset/sync.go` and `helper/csv.go`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (clean)