### PR TITLE
Add IdlePeriod() to PringsSpecialK

### DIFF
--- a/momentum/prings_special_k.go
+++ b/momentum/prings_special_k.go
@@ -139,6 +139,11 @@ func (p *PringsSpecialK[T]) ComputeWithContext(ctx context.Context, closings <-c
 	return p11
 }
 
+// IdlePeriod is the initial period that Pring's Special K won't yield any results.
+func (p *PringsSpecialK[T]) IdlePeriod() int {
+	return p.Sma195Roc530.IdlePeriod() + p.Roc530.IdlePeriod()
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/momentum/prings_special_k_test.go
+++ b/momentum/prings_special_k_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/cinar/indicator/v2/helper"
-	"github.com/cinar/indicator/v2/trend"
 )
 
 func TestNewPringsSpecialKInitialization(t *testing.T) {
@@ -70,9 +69,7 @@ func pringsSpecialKComputeOutputLengthOnInputLength(inputLen int) int {
 
 // Test sufficient number of samples for output
 func TestPringsSpecialKComputeBasicOutput(t *testing.T) {
-	sma530 := trend.NewSmaWithPeriod[float64](530)
-	roc195 := trend.NewRocWithPeriod[float64](195)
-	minimumRequiredInputLength := sma530.IdlePeriod() + roc195.IdlePeriod() + 1
+	minimumRequiredInputLength := NewPringsSpecialK[float64]().IdlePeriod() + 1
 
 	expectedOutputLen := 0
 	actualOutputLen := pringsSpecialKComputeOutputLengthOnInputLength(minimumRequiredInputLength - 1)
@@ -83,6 +80,15 @@ func TestPringsSpecialKComputeBasicOutput(t *testing.T) {
 	actualOutputLen = pringsSpecialKComputeOutputLengthOnInputLength(minimumRequiredInputLength)
 	if actualOutputLen != expectedOutputLen {
 		t.Errorf("Expected %d output values, got %d", expectedOutputLen, actualOutputLen)
+	}
+}
+
+func TestPringsSpecialKIdlePeriod(t *testing.T) {
+	psk := NewPringsSpecialK[float64]()
+
+	expected := psk.Sma195Roc530.IdlePeriod() + psk.Roc530.IdlePeriod()
+	if psk.IdlePeriod() != expected {
+		t.Fatalf("expected IdlePeriod %d, got %d", expected, psk.IdlePeriod())
 	}
 }
 


### PR DESCRIPTION
Closes #418.

## What was missing

Every other indicator in this library implements `IdlePeriod() int` (the subject of the consistency sweep in #413) so a caller knows how many leading values to skip before the output channel starts yielding real data. `PringsSpecialK` didn't, even though `ComputeWithContext` already computes exactly this value internally:

```go
maxIdle := p.Sma195Roc530.IdlePeriod() + p.Roc530.IdlePeriod()
```

used to align every other SMA(ROC(...)) branch to the slowest one. Without an exposed `IdlePeriod()`, a generic caller (e.g. the indicator registry in #416) has no way to know how many leading dates correspond to its warm-up — which, with the default periods, is 724.

Its own test already worked around this by reconstructing an equivalent value from unrelated standalone `Sma`/`Roc` instances rather than calling a method on the type itself — a sign the type should expose it.

## Fix

```go
// IdlePeriod is the initial period that Pring's Special K won't yield any results.
func (p *PringsSpecialK[T]) IdlePeriod() int {
	return p.Sma195Roc530.IdlePeriod() + p.Roc530.IdlePeriod()
}
```

`TestPringsSpecialKComputeBasicOutput` now calls `IdlePeriod()` on the actual instance instead of hand-reconstructing the number from a throwaway `Sma(530)`/`Roc(195)` pair (which happened to total the same value only because `(530-1)+195 == 194+530`) — it already passed before this change and still does, confirming the new method's value matches what that test independently expected all along. Added `TestPringsSpecialKIdlePeriod` as a direct check.

## Test plan

- [x] `go test -race -cover ./momentum/...` — 92.4% coverage
- [x] `go vet`, `staticcheck`, `gosec` clean on `momentum/` (an unrelated pre-existing `revive` finding in `rvi.go`, a file this PR doesn't touch, is untouched)
- [x] `go build ./...` and the full `INDICATOR_BASE` test suite (`asset`, `backtest`, `cmd`, `helper`, `momentum`, `strategy`, `trend`, `volatility`, `volume`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)