### PR TITLE
Fix T3 dropping most of its output

### DIFF
--- a/trend/t3.go
+++ b/trend/t3.go
@@ -77,13 +77,26 @@ func NewT3WithPeriodAndFactor[T helper.Float](period int, volumeFactor float64) 
 
 // ComputeWithContext function takes a channel of numbers and computes the T3 Moving Average.
 func (t *T3[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-chan T {
-	// Chain 6 EMAs
+	// Chain 6 EMAs. ema3, ema4, and ema5 each feed the next EMA in the
+	// chain *and* are used directly below in the weighted sum, so each
+	// needs its own duplicated copy for the second use -- a single
+	// channel only has one consumer's worth of values to give out.
 	ema1 := t.ema1.ComputeWithContext(ctx, closings)
 	ema2 := t.ema2.ComputeWithContext(ctx, ema1)
-	ema3 := t.ema3.ComputeWithContext(ctx, ema2)
-	ema4 := t.ema4.ComputeWithContext(ctx, ema3)
-	ema5 := t.ema5.ComputeWithContext(ctx, ema4)
-	ema6 := t.ema6.ComputeWithContext(ctx, ema5)
+
+	ema3Splice := helper.DuplicateWithContext(ctx, t.ema3.ComputeWithContext(ctx, ema2), 2)
+	ema4Splice := helper.DuplicateWithContext(ctx, t.ema4.ComputeWithContext(ctx, ema3Splice[0]), 2)
+	ema5Splice := helper.DuplicateWithContext(ctx, t.ema5.ComputeWithContext(ctx, ema4Splice[0]), 2)
+	ema6 := t.ema6.ComputeWithContext(ctx, ema5Splice[0])
+
+	// Each EMA only starts yielding once it has Period-1 more inputs than
+	// it was given, so ema3/ema4/ema5's channels run ahead of ema6's by
+	// 3/2/1 EMA delays respectively. Skip that many off each so that,
+	// read in lockstep with ema6, they land on the same closing.
+	idle := t.Period - 1
+	ema3Aligned := helper.SkipWithContext(ctx, ema3Splice[1], 3*idle)
+	ema4Aligned := helper.SkipWithContext(ctx, ema4Splice[1], 2*idle)
+	ema5Aligned := helper.SkipWithContext(ctx, ema5Splice[1], idle)
 
 	// Calculate coefficients based on volume factor
 	a := float64(t.VolumeFactor)
@@ -95,10 +108,10 @@ func (t *T3[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-cha
 	// T3 = c1*EMA6 + c2*EMA6(EMA6) + c3*EMA6(EMA6(EMA6)) + c4*EMA6(EMA6(EMA6(EMA6)))
 	// Which is: c1*ema6 + c2*ema5 + c3*ema4 + c4*ema3
 	result := helper.AddWithContext(ctx, helper.AddWithContext(ctx, helper.MultiplyByWithContext(ctx, ema6, T(c1)),
-		helper.MultiplyByWithContext(ctx, ema5, T(c2)),
+		helper.MultiplyByWithContext(ctx, ema5Aligned, T(c2)),
 	),
-		helper.AddWithContext(ctx, helper.MultiplyByWithContext(ctx, ema4, T(c3)),
-			helper.MultiplyByWithContext(ctx, ema3, T(c4)),
+		helper.AddWithContext(ctx, helper.MultiplyByWithContext(ctx, ema4Aligned, T(c3)),
+			helper.MultiplyByWithContext(ctx, ema3Aligned, T(c4)),
 		),
 	)
 

--- a/trend/t3_test.go
+++ b/trend/t3_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestT3Simple(t *testing.T) {
-	prices := make([]float64, 50)
+	prices := make([]float64, 400)
 	for i := range prices {
 		prices[i] = 100 + float64(i)
 	}
@@ -24,8 +24,9 @@ func TestT3Simple(t *testing.T) {
 
 	resultSlice := helper.ChanToSlice(result)
 
-	if len(resultSlice) == 0 {
-		t.Fatal("T3 produced no output")
+	expected := len(prices) - t3.IdlePeriod()
+	if len(resultSlice) != expected {
+		t.Fatalf("expected %d values, got %d", expected, len(resultSlice))
 	}
 
 	for i, v := range resultSlice {
@@ -35,6 +36,70 @@ func TestT3Simple(t *testing.T) {
 	}
 
 	t.Logf("T3: %d values, first: %.2f", len(resultSlice), resultSlice[0])
+}
+
+// referenceEma reproduces Ema's algorithm (SMA-seeded start, then the
+// standard EMA recurrence) over a plain slice, to independently verify
+// T3's values rather than just its output length.
+func referenceEma(input []float64, period int) []float64 {
+	sum := 0.0
+	for i := 0; i < period; i++ {
+		sum += input[i]
+	}
+
+	prev := sum / float64(period)
+	out := []float64{prev}
+
+	multiplier := 2.0 / float64(period+1)
+	for i := period; i < len(input); i++ {
+		prev = (input[i]-prev)*multiplier + prev
+		out = append(out, prev)
+	}
+
+	return out
+}
+
+// TestT3Values guards against a regression where ema3, ema4, and ema5 were
+// each read by two consumers (the next EMA in the chain, and the final
+// weighted sum) without being duplicated first, and combined with ema6
+// without aligning for the extra EMA passes each is ahead by. Both silently
+// produced wrong output rather than a build or panic, so this compares
+// against an independently computed reference instead of just checking
+// length or NaN/Inf, the way TestT3Simple already did.
+func TestT3Values(t *testing.T) {
+	prices := make([]float64, 400)
+	for i := range prices {
+		prices[i] = 100 + float64(i%7)
+	}
+
+	period := trend.DefaultT3Period
+	factor := trend.DefaultT3VolumeFactor
+
+	t3 := trend.NewT3[float64]()
+	out := helper.ChanToSlice(t3.Compute(helper.SliceToChan(prices)))
+
+	expectedLen := len(prices) - t3.IdlePeriod()
+	if len(out) != expectedLen {
+		t.Fatalf("expected %d values, got %d", expectedLen, len(out))
+	}
+
+	ema3 := referenceEma(referenceEma(referenceEma(prices, period), period), period)
+	ema4 := referenceEma(ema3, period)
+	ema5 := referenceEma(ema4, period)
+	ema6 := referenceEma(ema5, period)
+
+	a := factor
+	c1, c2, c3, c4 := -math.Pow(a, 3), 3*math.Pow(a, 2), -3*a, math.Pow(a, 3)
+
+	tail := func(s []float64) []float64 { return s[len(s)-expectedLen:] }
+	e3, e4, e5, e6 := tail(ema3), tail(ema4), tail(ema5), tail(ema6)
+
+	for i := 0; i < expectedLen; i++ {
+		want := c1*e6[i] + c2*e5[i] + c3*e4[i] + c4*e3[i]
+		if math.Abs(want-out[i]) > 1e-9 {
+			t.Fatalf("value %d: expected %v, got %v", i, want, out[i])
+		}
+	}
 }
 
 func TestT3String(t *testing.T) {


### PR DESCRIPTION
Closes #419.

## Root cause (two compounding bugs)

**1. Three channels each read by two consumers without duplication.** `ema3`, `ema4`, and `ema5` each feed the next EMA in the chain (`ema4 := t.ema4.ComputeWithContext(ctx, ema3)`, etc.) *and* are used directly in the final weighted sum (`c4*ema3`, `c3*ema4`, `c2*ema5`). A Go channel only has one consumer's worth of values to give out — with two readers racing for each one, both get a random, partial subset, and that starvation cascades through every stage downstream. With 400 closings in, `IdlePeriod()` said 376 values should come out; only 93 did (see #419 for the original repro).

**2. Even fixed, the branches weren't time-aligned before summing.** This codebase's `Ema` only starts emitting once it has `Period-1` more inputs than it's given, so each extra EMA pass in a chain shifts that branch further ahead in time relative to a less-chained one — `ema3`'s stream runs 3 EMA-delays ahead of `ema6`'s, `ema4` 2 ahead, `ema5` 1 ahead. `Macd` already does exactly this kind of alignment (skipping its faster EMA branch by the period difference) before combining two differently-delayed EMAs; `T3` combined four without it, which would have paired each closing with values computed from EMAs 1–3 dates further along.

## Fix

Duplicate `ema3`/`ema4`/`ema5` before their second use, and skip each by `3`/`2`/`1` times `(Period-1)` before summing with `ema6`, mirroring the pattern `Macd` already uses.

## Test plan

- `TestT3Simple` previously only checked for a non-zero, non-NaN/Inf result — passed either way, which is how bug #2 in particular could ship unnoticed (it produces neither symptom). Now asserts the exact expected length (`len(input) - IdlePeriod()`).
- New `TestT3Values`: computes an independent reference EMA chain over the same input and cross-checks every output value against the documented formula (`c1*ema6 + c2*ema5 + c3*ema4 + c4*ema3`), not just length — this is what actually catches bug #2.
- [x] `go test -race -cover ./trend/...` — 91.6% coverage, no races
- [x] `go vet`, `staticcheck`, `revive`, `gosec` clean on `trend/`
- [x] `go build ./...` and the full `INDICATOR_BASE` test suite pass. `T3` isn't referenced anywhere else in the codebase yet, so this is self-contained to `trend/t3.go`/`trend/t3_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)