### PR TITLE
Fix STC dividing by a near-zero denominator, producing -Inf/huge out-of-range swings

### DIFF
--- a/trend/stc.go
+++ b/trend/stc.go
@@ -33,10 +33,17 @@ const (
 //	EMA2 = EMA(values, slowPeriod)
 //	MACD = EMA1 - EMA2
 //
-//	%K = Stochastic %K of MACD with kPeriod
-//	%D = Stochastic %D of MACD with dPeriod
+//	%K1, %D1 = Stochastic(MACD, kPeriod, dPeriod)
+//	%K2, %D2 = Stochastic(%D1, kPeriod, dPeriod)
 //
-//	STC = 100 * (MACD - %K) / (%D - %K)
+//	STC = %D2
+//
+// The Stochastic pass (rolling-min/max normalization to a 0-100 range,
+// then smoothed by an SMA) is applied twice, once to MACD and again to
+// the first pass's %D, the way the standard Schaff Trend Cycle algorithm
+// double-smooths MACD -- not once to MACD with a second division against
+// its own %K/%D, which isn't bounded to 0-100 and can divide by a
+// near-zero denominator.
 //
 // Example:
 //
@@ -96,47 +103,22 @@ func (s *Stc[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 	c = helper.BufferedWithContext(ctx, c, s.SlowPeriod)
 	macd := s.Apo.ComputeWithContext(ctx, c)
 
-	macd = helper.BufferedWithContext(ctx, macd, s.Stochastic.Period)
-	inputs := helper.DuplicateWithContext(ctx, macd, 4)
+	// %K1 and %K2 are unused (STC only needs the doubly-smoothed %D), but
+	// each comes from the same internal duplicate fan-out as %D1/%D2, so
+	// it still has to be drained -- an unread duplicate branch blocks the
+	// shared producer, stalling %D1/%D2 too.
+	k1, d1 := s.Stochastic.ComputeWithContext(ctx, macd)
+	go helper.DrainWithContext(ctx, k1)
 
-	movingMin := NewMovingMinWithPeriod[T](s.Stochastic.Period)
-	movingMax := NewMovingMaxWithPeriod[T](s.Stochastic.Period)
+	k2, d2 := s.Stochastic.ComputeWithContext(ctx, d1)
+	go helper.DrainWithContext(ctx, k2)
 
-	lowestSplice := helper.DuplicateWithContext(ctx, movingMin.ComputeWithContext(ctx, inputs[0]),
-		2,
-	)
-
-	highest := movingMax.ComputeWithContext(ctx, inputs[1])
-
-	skipped := helper.SkipWithContext(ctx, inputs[2], movingMin.IdlePeriod())
-
-	kValues := helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, skipped, lowestSplice[0]),
-		helper.SubtractWithContext(ctx, highest, lowestSplice[1]),
-	),
-		100,
-	)
-
-	kDuplicate := helper.DuplicateWithContext(ctx, kValues, 2)
-
-	d := s.Stochastic.Sma.ComputeWithContext(ctx, kDuplicate[0])
-
-	kForStcSplice := helper.DuplicateWithContext(ctx,
-		helper.SkipWithContext(ctx, kDuplicate[1], s.Stochastic.Sma.IdlePeriod()),
-		2,
-	)
-
-	macdForStc := helper.SkipWithContext(ctx, inputs[3], s.Stochastic.IdlePeriod())
-
-	return helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, macdForStc, kForStcSplice[0]),
-		helper.SubtractWithContext(ctx, d, kForStcSplice[1]),
-	),
-		100,
-	)
+	return d2
 }
 
 // IdlePeriod is the initial period that STC won't yield any results.
 func (s *Stc[T]) IdlePeriod() int {
-	return s.Apo.IdlePeriod() + s.Stochastic.IdlePeriod()
+	return s.Apo.IdlePeriod() + 2*s.Stochastic.IdlePeriod()
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/stc_test.go
+++ b/trend/stc_test.go
@@ -51,27 +51,23 @@ func TestStcSlowStochastic(t *testing.T) {
 	}
 }
 
+// TestStcFull checks that STC's output length matches IdlePeriod() once the
+// Stochastic pass is applied twice (once to MACD, again to its %D), which
+// needs more warm-up than the 19-row testdata/stochastic.csv fixture
+// (shared with TestStcSlowStochastic/TestStochastic) has, so this generates
+// its own longer synthetic series instead.
 func TestStcFull(t *testing.T) {
-	type Data struct {
-		Value float64
-		K     float64
-		D     float64
+	values := make([]float64, 200)
+	for i := range values {
+		values[i] = 100 + float64(i%7)
 	}
-
-	input, err := helper.ReadFromCsvFile[Data]("testdata/stochastic.csv")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	inputSlice := helper.ChanToSlice(input)
-	values := helper.Map(helper.SliceToChan(inputSlice), func(d *Data) float64 { return d.Value })
 
 	stc := trend.NewStcWithPeriod[float64](5, 10, 5, 3)
-	result := stc.Compute(values)
+	result := stc.Compute(helper.SliceToChan(values))
 
 	slice := helper.ChanToSlice(result)
 
-	expected := len(inputSlice) - stc.IdlePeriod()
+	expected := len(values) - stc.IdlePeriod()
 	if len(slice) != expected {
 		t.Fatalf("expected %d values, got %d", expected, len(slice))
 	}


### PR DESCRIPTION
Closes #425.

## Summary

- `trend.Stc.ComputeWithContext` divided `(MACD-%K)/(%D-%K)` for its final line, per the doc comment's `STC = 100 * (MACD - %K) / (%D - %K)`. `%D-%K` is frequently near zero (both are stochastic-smoothed values of the same MACD series and track each other closely), so real-world input yields `-Inf` and swings like `1435`/`-710` for an indicator documented to oscillate 0-100.
- Replaced with the standard Schaff Trend Cycle algorithm: apply the existing `Stochastic` (rolling-min/max normalization + SMA) *twice* -- once to MACD to get `%K1`/`%D1`, then again to `%D1` to get `%K2`/`%D2` -- with `STC = %D2`. Both stages stay bounded in [0, 100] by construction.
- `%K1`/`%K2` are discarded (STC only needs the doubly-smoothed `%D`), but each comes from the same internal duplicate fan-out as `%D1`/`%D2` inside `Stochastic.ComputeWithContext`, so each is drained in its own goroutine (`helper.DrainWithContext`) -- an unread duplicate branch otherwise blocks the shared producer and stalls `%D1`/`%D2` too (this reintroduces the class of deadlock #421 fixed if skipped).
- `IdlePeriod()` updated to `Apo.IdlePeriod() + 2*Stochastic.IdlePeriod()` to match the now-doubled warm-up.
- `TestStcFull`'s fixture (`testdata/stochastic.csv`, 19 rows, shared with two other tests) is too short for the new warm-up, so it now generates its own longer synthetic series instead.

## Note on remaining NaN

STC can still legitimately output `NaN` when a stochastic stage's rolling window is exactly flat (a genuine 0/0). Separately, I found that `trend.MovingSum` (which the `Sma` inside `Stochastic` uses) doesn't recover from a single `NaN` even after it leaves the window -- filed and fixed separately as #427 / PR (fix/movingsum-nan-poisoning), since it's a shared primitive bug, not specific to STC. With that fix applied too, STC on a 251-day BRK-B series drops from 157/180 NaN outputs down to 36/180, with the rest being either the initial warm-up or a genuinely flat window at the very tail (no future data to recover into). Without it, STC's math is still correct here, just noisier in practice on real data until #427 lands.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (full repo, no regressions)
- [x] `go vet`, `gosec`, `staticcheck`, `revive` clean on `trend/`
- [x] Manual check against `asset/testdata/repository/brk-b.csv`: output now bounded in [0, 100] (previously `-Inf`, `1435`, `-710`, etc.)
- [x] New `TestStcFull` (longer synthetic fixture) and existing `TestStcDeadlock`/`TestStcSlowStochastic` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)