### PR TITLE
Fix T3's weighted-sum coefficients not summing to 1

### DIFF
--- a/trend/t3.go
+++ b/trend/t3.go
@@ -6,7 +6,6 @@ package trend
 
 import (
 	"fmt"
-	"math"
 
 	"context"
 
@@ -31,10 +30,13 @@ const (
 // where:
 //
 //	c1 = -a^3
-//	c2 = 3a^2
-//	c3 = -3a
-//	c4 = a^3
+//	c2 = 3a^2 + 3a^3
+//	c3 = -6a^2 - 3a - 3a^3
+//	c4 = 1 + 3a + 3a^2 + a^3
 //	a = volume factor
+//
+// The coefficients sum to 1 for any a, the way a weighted moving average's
+// must, so T3 reproduces a constant input exactly.
 //
 // Example:
 //
@@ -98,12 +100,16 @@ func (t *T3[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-cha
 	ema4Aligned := helper.SkipWithContext(ctx, ema4Splice[1], 2*idle)
 	ema5Aligned := helper.SkipWithContext(ctx, ema5Splice[1], idle)
 
-	// Calculate coefficients based on volume factor
+	// Calculate coefficients based on volume factor. These sum to 1 for
+	// any a (verify: -a^3 + 3a^2+3a^3 -6a^2-3a-3a^3 + 1+3a+3a^2+a^3 = 1),
+	// as required of a weighted moving average.
 	a := float64(t.VolumeFactor)
-	c1 := -math.Pow(a, 3)
-	c2 := 3 * math.Pow(a, 2)
-	c3 := -3 * a
-	c4 := math.Pow(a, 3)
+	a2 := a * a
+	a3 := a2 * a
+	c1 := -a3
+	c2 := 3*a2 + 3*a3
+	c3 := -6*a2 - 3*a - 3*a3
+	c4 := 1 + 3*a + 3*a2 + a3
 
 	// T3 = c1*EMA6 + c2*EMA6(EMA6) + c3*EMA6(EMA6(EMA6)) + c4*EMA6(EMA6(EMA6(EMA6)))
 	// Which is: c1*ema6 + c2*ema5 + c3*ema4 + c4*ema3

--- a/trend/t3_test.go
+++ b/trend/t3_test.go
@@ -89,7 +89,8 @@ func TestT3Values(t *testing.T) {
 	ema6 := referenceEma(ema5, period)
 
 	a := factor
-	c1, c2, c3, c4 := -math.Pow(a, 3), 3*math.Pow(a, 2), -3*a, math.Pow(a, 3)
+	a2, a3 := a*a, a*a*a
+	c1, c2, c3, c4 := -a3, 3*a2+3*a3, -6*a2-3*a-3*a3, 1+3*a+3*a2+a3
 
 	tail := func(s []float64) []float64 { return s[len(s)-expectedLen:] }
 	e3, e4, e5, e6 := tail(ema3), tail(ema4), tail(ema5), tail(ema6)
@@ -98,6 +99,33 @@ func TestT3Values(t *testing.T) {
 		want := c1*e6[i] + c2*e5[i] + c3*e4[i] + c4*e3[i]
 		if math.Abs(want-out[i]) > 1e-9 {
 			t.Fatalf("value %d: expected %v, got %v", i, want, out[i])
+		}
+	}
+}
+
+// TestT3FlatInput guards against a regression where the weighted-sum
+// coefficients didn't sum to 1 (c1+c2+c3+c4 = 3a(a-1) instead of 1 for the
+// old, wrong coefficients), which meant T3 didn't track price at all -- a
+// flat 100 series came out as -63. A moving average's weights must sum to
+// 1, so a constant input should reproduce that same constant.
+func TestT3FlatInput(t *testing.T) {
+	const flat = 100.0
+
+	prices := make([]float64, 100)
+	for i := range prices {
+		prices[i] = flat
+	}
+
+	t3 := trend.NewT3[float64]()
+	out := helper.ChanToSlice(t3.Compute(helper.SliceToChan(prices)))
+
+	if len(out) == 0 {
+		t.Fatal("expected at least one value")
+	}
+
+	for i, v := range out {
+		if math.Abs(v-flat) > 1e-9 {
+			t.Fatalf("value %d: expected %v (flat input), got %v", i, flat, v)
 		}
 	}
 }


### PR DESCRIPTION
Closes #426.

## Summary

- `trend.T3.ComputeWithContext` used `c1=-a^3, c2=3a^2, c3=-3a, c4=a^3` for its weighted sum of the 6-EMA chain. These sum to `3a(a-1)` instead of 1, so T3 didn't track price at all -- a flat 100 series returned `-63` instead of `100` with the default `VolumeFactor=0.7`, and on real BRK-B closings (~$318-359) it output ~`-193`.
- Replaced with the standard Tillson T3 coefficients (`GD(x) = EMA(x)*(1+a) - EMA(EMA(x))*a`, composed three times): `c1=-a^3, c2=3a^2+3a^3, c3=-6a^2-3a-3a^3, c4=1+3a+3a^2+a^3`. These sum to exactly 1 for any `a`, as required of a weighted moving average.
- Added `TestT3FlatInput`, asserting a constant input reproduces that same constant -- the property that was violated. Fixed `TestT3Values`' independent reference to use the corrected coefficients too (it previously encoded the same wrong formula as its "ground truth," so it passed despite the bug).

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (full repo, no regressions)
- [x] `go vet`, `gosec`, `staticcheck`, `revive` clean on `trend/`
- [x] Manual check: flat 100-input now returns 100; real BRK-B closings (~$318-359) now return T3 values in the ~$310-362 range instead of large negative numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)