### PR TITLE
Fix MovingSum's running sum staying NaN/Inf forever after one bad value

### DIFF
--- a/trend/moving_sum.go
+++ b/trend/moving_sum.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"math"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -44,6 +45,15 @@ func NewMovingSumWithPeriod[T helper.Number](period int) *MovingSum[T] {
 // sum, which happens whenever the window sum is near zero — e.g. a Cmf or
 // Mfi moving sum of signed money flow in a quiet market. For integer T the
 // compensation term is always zero, so behavior is unchanged.
+//
+// A NaN or Inf value (e.g. a 0/0 upstream, from a genuinely flat window in
+// some other indicator built on this one) would otherwise poison the
+// running sum forever: subtracting the value back out once it leaves the
+// window doesn't undo NaN/Inf contamination arithmetically. A small ring
+// buffer of the current window's raw values lets the sum be recomputed
+// from scratch whenever that happens, so the output recovers as soon as
+// the bad value actually leaves the window, instead of staying NaN/Inf for
+// the rest of the series.
 func (m *MovingSum[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 	cs := helper.DuplicateWithContext(ctx, c, 2)
 	cs[1] = helper.ShiftWithContext(ctx, cs[1], m.Period, 0)
@@ -51,11 +61,34 @@ func (m *MovingSum[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-cha
 	sum := T(0)
 	comp := T(0)
 
+	window := make([]T, m.Period)
+	next := 0
+	filled := 0
+
 	sums := helper.OperateWithContext(ctx, cs[0], cs[1], func(c, b T) T {
+		window[next] = c
+		next = (next + 1) % m.Period
+
+		if filled < m.Period {
+			filled++
+		}
+
 		sum, comp = neumaierAdd(sum, comp, c)
 		sum, comp = neumaierAdd(sum, comp, -b)
 
-		return sum + comp
+		result := sum + comp
+
+		if isNaNOrInf(result) {
+			sum, comp = T(0), T(0)
+
+			for i := 0; i < filled; i++ {
+				sum, comp = neumaierAdd(sum, comp, window[i])
+			}
+
+			result = sum + comp
+		}
+
+		return result
 	})
 
 	return helper.SkipWithContext(ctx, sums, m.Period-1)
@@ -83,6 +116,14 @@ func absT[T helper.Number](v T) T {
 	}
 
 	return v
+}
+
+// isNaNOrInf reports whether v is NaN or +/-Inf. For integer T this is
+// always false; float64(v) can't spuriously become Inf for any value an
+// integer type can actually hold.
+func isNaNOrInf[T helper.Number](v T) bool {
+	f := float64(v)
+	return math.IsNaN(f) || math.IsInf(f, 0)
 }
 
 // IdlePeriod is the initial period that Moving Sum won't yield any results.

--- a/trend/moving_sum_test.go
+++ b/trend/moving_sum_test.go
@@ -99,6 +99,51 @@ func TestMovingSumFloatDrift(t *testing.T) {
 	}
 }
 
+// TestMovingSumRecoversFromNaN guards against a regression where a single
+// NaN entering the running sum poisoned every output for the rest of the
+// series, even long after that NaN left the window: subtracting a value
+// back out (`sum - NaN`) doesn't undo NaN contamination, since the running
+// sum itself had already become NaN. The output should only be NaN while
+// the NaN value is actually within the window, and recover to a correct,
+// finite sum as soon as it slides out.
+func TestMovingSumRecoversFromNaN(t *testing.T) {
+	const period = 4
+
+	values := []float64{1, 2, 3, math.NaN(), 4, 5, 6, 7, 8, 9}
+
+	sum := trend.NewMovingSum[float64]()
+	sum.Period = period
+
+	actual := helper.ChanToSlice(sum.Compute(helper.SliceToChan(values)))
+
+	expectedLen := len(values) - (period - 1)
+	if len(actual) != expectedLen {
+		t.Fatalf("expected %d values, got %d", expectedLen, len(actual))
+	}
+
+	for i, v := range actual {
+		// Window i covers values[i : i+period]; NaN is at index 3.
+		wantNaN := i <= 3 && i+period > 3
+
+		if wantNaN {
+			if !math.IsNaN(v) {
+				t.Fatalf("value %d: expected NaN (window still contains the NaN input), got %v", i, v)
+			}
+
+			continue
+		}
+
+		var want float64
+		for j := i; j < i+period; j++ {
+			want += values[j]
+		}
+
+		if math.Abs(v-want) > 1e-9 {
+			t.Fatalf("value %d: expected %v once the NaN left the window, got %v", i, want, v)
+		}
+	}
+}
+
 // TestMovingSumFloatDriftNearZeroSum exercises the regime where the window
 // sum is near zero while individual terms are much larger in magnitude —
 // the shape of a Cmf or Mfi moving sum of signed money flow in a quiet


### PR DESCRIPTION
Closes #427.

## Summary

- `trend.MovingSum.ComputeWithContext` accumulates a running sum incrementally (add the new value, subtract the value leaving the window) with Neumaier compensated summation (#411). That's correct for bounding float drift, but a single `NaN` or `Inf` entering the sum poisons it forever: `sum - oldValue` doesn't undo `NaN`/`Inf` contamination, so every output after the first bad value stayed `NaN`/`Inf` for the rest of the series, even long after that value actually left the window.
- Found while fixing STC's formula (#425): once corrected to the proper double stochastic pass, a single flat MACD window anywhere in a real BRK-B series took STC permanently NaN for 157 of 180 remaining outputs. This isn't specific to STC or MACD -- it's any indicator built on `Sma` that can see a genuine 0/0 upstream.
- Fix: a small ring buffer of the current window's raw values lets the sum be recomputed from scratch whenever the incremental result comes out non-finite, so output self-heals as soon as the bad value actually leaves the window, instead of staying `NaN`/`Inf` for the rest of the series. Common case stays O(1)-per-step; only the rare contaminated stretch pays an O(period) recompute.
- Added `TestMovingSumRecoversFromNaN`, asserting output is `NaN` only for the windows that actually contain the injected `NaN`, and correct/finite for every window once it's slid out.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (full repo, no regressions -- this is a widely-shared primitive)
- [x] `go vet`, `gosec`, `staticcheck`, `revive` clean on `trend/`
- [x] Existing `TestMovingSumFloatDrift`/`TestMovingSumFloatDriftNearZeroSum` (from #411) still pass, confirming the Neumaier drift-bounding behavior is unchanged
- [x] Combined with the STC fix (#425) on real BRK-B data: NaN outputs drop from 157/180 to 36/180, the rest being either warm-up or a genuinely flat window at the very tail of the data

🤖 Generated with [Claude Code](https://claude.com/claude-code)