### PR TITLE
Fix PercentBandMFIStrategy default constructor swapping buy/sell thresholds

### DIFF
--- a/strategy/volume/percent_b_and_mfi_strategy.go
+++ b/strategy/volume/percent_b_and_mfi_strategy.go
@@ -56,10 +56,10 @@ type PercentBandMFIStrategy struct {
 // NewPercentBandMFIStrategy function initializes a new PercentBandMFI strategy instance with the default parameters.
 func NewPercentBandMFIStrategy() *PercentBandMFIStrategy {
 	return NewPercentBandMFIStrategyWith(
-		DefaultPercentBandMFIStrategyPercentBBuyAt,
 		DefaultPercentBandMFIStrategyPercentBSellAt,
-		DefaultPercentBandMFIStrategyMfiBuyAt,
+		DefaultPercentBandMFIStrategyPercentBBuyAt,
 		DefaultPercentBandMFIStrategyMfiSellAt,
+		DefaultPercentBandMFIStrategyMfiBuyAt,
 	)
 }
 


### PR DESCRIPTION
## Summary
- `NewPercentBandMFIStrategyWith`'s signature is `(sellPercentBAt, buyPercentBAt, sellMfiAt, buyMfiAt)`, but `NewPercentBandMFIStrategy()` (the default/no-arg constructor) passed the Buy-default constants (`0.8`, `80`) into the first two (Sell) slots and the Sell-default constants (`0.2`, `20`) into the last two (Buy) slots — a positional-argument mismatch.
- The type's own doc comment says: "Recommends a Buy action when %B is above 0.8 and MFI is above 80, and recommends a Sell action when %B is below 0.2 and MFI is below 20." With the swapped defaults, the strategy did the opposite: it bought on low %B/MFI and sold on high %B/MFI.
- Fix: swap the argument order in the default constructor's call to `NewPercentBandMFIStrategyWith` so `SellPercentBAt=0.2`, `BuyPercentBAt=0.8`, `SellMfiAt=20`, `BuyMfiAt=80`, matching the documented behavior.
- No test fixture regeneration needed — the existing tests (`TestPercentBandMFIStrategy`, `TestPercentBandMFIStrategyReport`) are smoke tests only (drain the action channel / check the report is non-nil), they don't assert specific Buy/Sell values, so they wouldn't have caught this bug and don't need updating for the fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S57gZv4WTFaYdREMPLpBJY