### PR TITLE
Fix Woodie pivot point S3 formula inconsistent with its own R3

### DIFF
--- a/trend/pivot_point.go
+++ b/trend/pivot_point.go
@@ -163,7 +163,7 @@ func (p *PivotPoint[T]) calculate(h, l, c, currO T) PivotPointResult[T] {
 		res.R2 = res.P + (h - l)
 		res.S2 = res.P - (h - l)
 		res.R3 = h + 2*(res.P-l)
-		res.S3 = l - 2*(res.P-l)
+		res.S3 = l - 2*(h-res.P)
 
 	case PivotPointCamarilla:
 		diff := h - l

--- a/trend/pivot_point_test.go
+++ b/trend/pivot_point_test.go
@@ -81,7 +81,7 @@ func TestPivotPointWoodie(t *testing.T) {
 	// Second bar: O=319
 	// Woodie P = (318.600006 + 308.700012 + 2 * 319) / 4 = 316.3250045
 	// Woodie R3 = 318.600006 + 2 * (316.3250045 - 308.700012) = 333.85
-	// Woodie S3 = 308.700012 - 2 * (316.3250045 - 308.700012) = 293.450027
+	// Woodie S3 = 308.700012 - 2 * (318.600006 - 316.3250045) = 304.150009
 
 	res := <-results
 
@@ -93,8 +93,8 @@ func TestPivotPointWoodie(t *testing.T) {
 		t.Fatalf("expected R3 333.85, got %v", res.R3)
 	}
 
-	if helper.RoundDigit(res.S3, 6) != 293.450027 {
-		t.Fatalf("expected S3 293.450027, got %v", res.S3)
+	if helper.RoundDigit(res.S3, 6) != 304.150009 {
+		t.Fatalf("expected S3 304.150009, got %v", res.S3)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Woodie pivot point's S3 used `l - 2*(P-l)` instead of `l - 2*(h-P)`, inconsistent with Woodie's own R3 (`h + 2*(P-l)`) right above it in the same file, and with the Standard pivot's R3/S3 mirror pair (`h + 2*(P-l)` / `l - 2*(h-P)`) already used elsewhere.
- Fixed `trend/pivot_point.go`'s Woodie case to mirror R3 correctly.
- Regenerated the hand-computed expected S3 value in `TestPivotPointWoodie` (304.150009, was 293.450027) — verified independently in Python.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all pass)