### PR TITLE
Remove default strategy list from indicator-backtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@
 *.so
 *.dylib
 bin
-indicator-backtest
-indicator-sync
+/indicator-backtest
+/indicator-sync
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -290,15 +290,18 @@ if err != nil {
 }
 ```
 
-The `indicator-backtest` command line tool empowers users to conduct comprehensive backtesting of assets residing within a specified repository. This capability encompasses the application of all currently recognized strategies, culminating in the generation of detailed reports within a designated output directory.
+The `indicator-backtest` command line tool empowers users to conduct comprehensive backtesting of assets residing within a specified repository. It does not run any strategy by default — you must explicitly name the strategies to backtest with the `-strategies` flag, culminating in the generation of detailed reports within a designated output directory.
 
 ```bash
 $ indicator-backtest \
-    -source-name filesystem \
-    -source-config /home/user/assets \
-    -output /home/user/reports \
+    -repository-name filesystem \
+    -repository-config /home/user/assets \
+    -report-config /home/user/reports \
+    -strategies apo,macd,rsi \
     -workers 1
 ```
+
+Run `indicator-backtest -list-strategies` to print the full list of strategy names that are available to pass to `-strategies`.
 
 🐳 Docker
 ---------
@@ -316,7 +319,8 @@ docker run -it --rm \
   ghcr.io/cinar/indicator:latest \
   --api-key YOUR_TIINGO_API_KEY \
   --days 365 \
-  --assets aapl msft googl
+  --assets aapl msft googl \
+  --strategies apo,macd,rsi
 
 # View results (macOS)
 open output/index.html
@@ -333,7 +337,10 @@ xdg-open output/index.html
 | `--days` | Days of historical data to fetch | 365 |
 | `--last` | Days to backtest | 365 |
 | `--assets` | Space-separated ticker symbols (default: all) | all |
+| `--strategies` | Comma-separated strategy names to backtest (required) | - |
 | `--output` | Output directory for reports | /app/output |
+
+Run `docker run --rm --entrypoint ./indicator-backtest ghcr.io/cinar/indicator:latest -list-strategies` to see the available strategy names.
 
 ### Examples
 
@@ -342,7 +349,8 @@ xdg-open output/index.html
 docker run -it --rm \
   -v $(pwd)/reports:/app/output \
   ghcr.io/cinar/indicator:latest \
-  --api-key YOUR_TIINGO_API_KEY
+  --api-key YOUR_TIINGO_API_KEY \
+  --strategies apo,macd,rsi
 
 # Backtest specific stocks for last 6 months, test last 30 days
 docker run -it --rm \
@@ -351,13 +359,15 @@ docker run -it --rm \
   --api-key YOUR_TIINGO_API_KEY \
   --days 180 \
   --last 30 \
-  --assets aapl msft googl amzn
+  --assets aapl msft googl amzn \
+  --strategies apo,macd,rsi
 
 # Custom output directory
 docker run -it --rm \
   -v /path/to/my/reports:/app/output \
   ghcr.io/cinar/indicator:latest \
   --api-key YOUR_TIINGO_API_KEY \
+  --strategies apo,macd,rsi \
   --output /app/output
 ```
 

--- a/cmd/indicator-backtest/main.go
+++ b/cmd/indicator-backtest/main.go
@@ -10,15 +10,11 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/cinar/indicator/v2/asset"
 	"github.com/cinar/indicator/v2/backtest"
 	"github.com/cinar/indicator/v2/strategy"
-	"github.com/cinar/indicator/v2/examples/compound"
-	"github.com/cinar/indicator/v2/examples/momentum"
-	"github.com/cinar/indicator/v2/examples/trend"
-	"github.com/cinar/indicator/v2/examples/volatility"
-	"github.com/cinar/indicator/v2/examples/volume"
 )
 
 func main() {
@@ -26,6 +22,8 @@ func main() {
 	var repositoryConfig string
 	var reportName string
 	var reportConfig string
+	var strategyNames string
+	var listStrategies bool
 	var workers int
 	var lastDays int
 	var addSplits bool
@@ -45,6 +43,8 @@ func main() {
 	flag.StringVar(&repositoryConfig, "repository-config", "", "repository config")
 	flag.StringVar(&reportName, "report-name", "html", "report name")
 	flag.StringVar(&reportConfig, "report-config", ".", "report type")
+	flag.StringVar(&strategyNames, "strategies", "", "comma-separated list of strategy names to backtest (see -list-strategies)")
+	flag.BoolVar(&listStrategies, "list-strategies", false, "list the available strategy names and exit")
 	flag.IntVar(&workers, "workers", backtest.DefaultBacktestWorkers, "number of concurrent workers")
 	flag.IntVar(&lastDays, "last", backtest.DefaultLastDays, "number of days to do backtest")
 	flag.BoolVar(&addSplits, "splits", false, "add the split strategies")
@@ -52,6 +52,19 @@ func main() {
 	flag.Parse()
 
 	logger := slog.Default()
+
+	if listStrategies {
+		for _, name := range StrategyNames() {
+			stdErr.Println(name)
+		}
+
+		return
+	}
+
+	if strategyNames == "" {
+		logger.Error("No strategies specified. Provide one or more with -strategies (comma-separated), or see -list-strategies for the available names.")
+		os.Exit(1)
+	}
 
 	source, err := asset.NewRepository(repositoryName, repositoryConfig)
 	if err != nil {
@@ -70,12 +83,18 @@ func main() {
 	backtester.LastDays = lastDays
 	backtester.Logger = logger
 	backtester.Names = append(backtester.Names, flag.Args()...)
-	backtester.Strategies = append(backtester.Strategies, compound.AllStrategies()...)
-	backtester.Strategies = append(backtester.Strategies, momentum.AllStrategies()...)
-	backtester.Strategies = append(backtester.Strategies, strategy.AllStrategies()...)
-	backtester.Strategies = append(backtester.Strategies, trend.AllStrategies()...)
-	backtester.Strategies = append(backtester.Strategies, volatility.AllStrategies()...)
-	backtester.Strategies = append(backtester.Strategies, volume.AllStrategies()...)
+
+	for _, name := range strings.Split(strategyNames, ",") {
+		name = strings.TrimSpace(name)
+
+		s, err := NewStrategy(name)
+		if err != nil {
+			logger.Error("Unable to initialize strategy.", "name", name, "error", err)
+			os.Exit(1)
+		}
+
+		backtester.Strategies = append(backtester.Strategies, s)
+	}
 
 	if addSplits {
 		backtester.Strategies = append(backtester.Strategies, strategy.AllSplitStrategies(backtester.Strategies)...)

--- a/cmd/indicator-backtest/strategy_registry.go
+++ b/cmd/indicator-backtest/strategy_registry.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/cinar/indicator/v2/examples/compound"
+	"github.com/cinar/indicator/v2/examples/momentum"
+	"github.com/cinar/indicator/v2/examples/trend"
+	"github.com/cinar/indicator/v2/examples/volatility"
+	"github.com/cinar/indicator/v2/examples/volume"
+	"github.com/cinar/indicator/v2/strategy"
+)
+
+// StrategyBuilderFunc defines a function that builds a new strategy instance.
+type StrategyBuilderFunc func() strategy.Strategy
+
+// strategyBuilders provides the name to strategy builder mapping for the
+// strategies that the indicator-backtest command line tool knows how to
+// build. Strategies are only ever added to a backtest run when the user
+// explicitly names them through the -strategies flag.
+var strategyBuilders = map[string]StrategyBuilderFunc{
+	"buy-and-hold": func() strategy.Strategy { return strategy.NewBuyAndHoldStrategy() },
+
+	"macd-rsi": func() strategy.Strategy { return compound.NewMacdRsiStrategy() },
+
+	"awesome-oscillator":    func() strategy.Strategy { return momentum.NewAwesomeOscillatorStrategy() },
+	"coppock-curve":         func() strategy.Strategy { return momentum.NewCoppockCurveStrategy() },
+	"elder-ray":             func() strategy.Strategy { return momentum.NewElderRayStrategy() },
+	"ichimoku-cloud":        func() strategy.Strategy { return momentum.NewIchimokuCloudStrategy() },
+	"rsi":                   func() strategy.Strategy { return momentum.NewRsiStrategy() },
+	"stochastic-oscillator": func() strategy.Strategy { return momentum.NewStochasticOscillatorStrategy() },
+	"stochastic-rsi":        func() strategy.Strategy { return momentum.NewStochasticRsiStrategy() },
+	"triple-rsi":            func() strategy.Strategy { return momentum.NewTripleRsiStrategy() },
+	"williams-r":            func() strategy.Strategy { return momentum.NewWilliamsRStrategy() },
+
+	"alligator":                       func() strategy.Strategy { return trend.NewAlligatorStrategy() },
+	"apo":                             func() strategy.Strategy { return trend.NewApoStrategy() },
+	"aroon":                           func() strategy.Strategy { return trend.NewAroonStrategy() },
+	"bop":                             func() strategy.Strategy { return trend.NewBopStrategy() },
+	"cci":                             func() strategy.Strategy { return trend.NewCciStrategy() },
+	"cfo":                             func() strategy.Strategy { return trend.NewCfoStrategy() },
+	"dema":                            func() strategy.Strategy { return trend.NewDemaStrategy() },
+	"golden-cross":                    func() strategy.Strategy { return trend.NewGoldenCrossStrategy() },
+	"hma":                             func() strategy.Strategy { return trend.NewHmaStrategy() },
+	"kama":                            func() strategy.Strategy { return trend.NewKamaStrategy() },
+	"kdj":                             func() strategy.Strategy { return trend.NewKdjStrategy() },
+	"macd":                            func() strategy.Strategy { return trend.NewMacdStrategy() },
+	"qstick":                          func() strategy.Strategy { return trend.NewQstickStrategy() },
+	"smma":                            func() strategy.Strategy { return trend.NewSmmaStrategy() },
+	"trima":                           func() strategy.Strategy { return trend.NewTrimaStrategy() },
+	"triple-moving-average-crossover": func() strategy.Strategy { return trend.NewTripleMovingAverageCrossoverStrategy() },
+	"tsi":                             func() strategy.Strategy { return trend.NewTsiStrategy() },
+	"vwma":                            func() strategy.Strategy { return trend.NewVwmaStrategy() },
+	"weighted-close":                  func() strategy.Strategy { return trend.NewWeightedCloseStrategy() },
+
+	"bollinger-bands":           func() strategy.Strategy { return volatility.NewBollingerBandsStrategy() },
+	"donchian-channel-breakout": func() strategy.Strategy { return volatility.NewDonchianChannelBreakoutStrategy() },
+	"keltner-channel":           func() strategy.Strategy { return volatility.NewKeltnerChannelStrategy() },
+	"super-trend":               func() strategy.Strategy { return volatility.NewSuperTrendStrategy() },
+
+	"chaikin-money-flow":     func() strategy.Strategy { return volume.NewChaikinMoneyFlowStrategy() },
+	"ease-of-movement":       func() strategy.Strategy { return volume.NewEaseOfMovementStrategy() },
+	"force-index":            func() strategy.Strategy { return volume.NewForceIndexStrategy() },
+	"money-flow-index":       func() strategy.Strategy { return volume.NewMoneyFlowIndexStrategy() },
+	"negative-volume-index":  func() strategy.Strategy { return volume.NewNegativeVolumeIndexStrategy() },
+	"obv":                    func() strategy.Strategy { return volume.NewObvStrategy() },
+	"weighted-average-price": func() strategy.Strategy { return volume.NewWeightedAveragePriceStrategy() },
+}
+
+// StrategyNames returns the sorted list of the registered strategy names.
+func StrategyNames() []string {
+	names := make([]string, 0, len(strategyBuilders))
+	for name := range strategyBuilders {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// NewStrategy builds a new strategy instance for the given registered name.
+func NewStrategy(name string) (strategy.Strategy, error) {
+	builder, ok := strategyBuilders[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown strategy: %s", name)
+	}
+
+	return builder(), nil
+}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,7 @@ API_KEY=""
 DAYS=365
 LAST=365
 ASSETS=""
+STRATEGIES=""
 OUTPUT="/app/output"
 DATA_DIR="/app/data"
 
@@ -18,15 +19,18 @@ show_usage() {
     echo "Sync market data from Tiingo and run backtests."
     echo ""
     echo "Options:"
-    echo "  --api-key KEY   Tiingo API key (required)"
-    echo "  --days N        Days of historical data to fetch (default: 365)"
-    echo "  --last N        Days to backtest (default: 365)"
-    echo "  --assets TICKERS Space-separated list of ticker symbols (default: all available)"
-    echo "  --output DIR    Output directory for reports (default: /app/output)"
-    echo "  --help          Show this help message"
+    echo "  --api-key KEY        Tiingo API key (required)"
+    echo "  --days N             Days of historical data to fetch (default: 365)"
+    echo "  --last N             Days to backtest (default: 365)"
+    echo "  --assets TICKERS     Space-separated list of ticker symbols (default: all available)"
+    echo "  --strategies NAMES   Comma-separated list of strategy names to backtest (required)"
+    echo "  --output DIR         Output directory for reports (default: /app/output)"
+    echo "  --help               Show this help message"
     echo ""
     echo "Example:"
-    echo "  indicator --api-key YOUR_KEY --days 365 --assets aapl msft googl"
+    echo "  indicator --api-key YOUR_KEY --days 365 --assets aapl msft googl --strategies apo,macd,rsi"
+    echo ""
+    echo "Run './indicator-backtest -list-strategies' inside the image to see the available strategy names."
     echo ""
     echo "Get your free Tiingo API key at: https://www.tiingo.com/"
 }
@@ -53,6 +57,10 @@ while [ $# -gt 0 ]; do
                 shift
             done
             ;;
+        --strategies)
+            STRATEGIES="$2"
+            shift 2
+            ;;
         --output)
             OUTPUT="$2"
             shift 2
@@ -76,6 +84,13 @@ if [ -z "$API_KEY" ]; then
     exit 1
 fi
 
+if [ -z "$STRATEGIES" ]; then
+    echo "Error: --strategies is required"
+    echo ""
+    show_usage
+    exit 1
+fi
+
 echo "=========================================="
 echo "Indicator Docker - Sync & Backtest"
 echo "=========================================="
@@ -85,6 +100,7 @@ echo "  API Key: ***"
 echo "  Days: $DAYS"
 echo "  Backtest Period: $LAST days"
 echo "  Assets: ${ASSETS:-all}"
+echo "  Strategies: $STRATEGIES"
 echo "  Output: $OUTPUT"
 echo ""
 
@@ -120,7 +136,8 @@ if [ -z "$ASSETS" ]; then
         -repository-config "$DATA_DIR" \
         -report-name html \
         -report-config "$OUTPUT" \
-        -last "$LAST"
+        -last "$LAST" \
+        -strategies "$STRATEGIES"
 else
     ./indicator-backtest \
         -repository-name filesystem \
@@ -128,6 +145,7 @@ else
         -report-name html \
         -report-config "$OUTPUT" \
         -last "$LAST" \
+        -strategies "$STRATEGIES" \
         $ASSETS
 fi
 


### PR DESCRIPTION
## Summary
- `indicator-backtest` no longer runs every example strategy by default; users must explicitly select strategies via the new `-strategies` flag (comma-separated names), with `-list-strategies` to discover what's available.
- Added `cmd/indicator-backtest/strategy_registry.go`, a name-to-builder registry for the 40 example strategies, mirroring the existing `asset.NewRepository`/`backtest.NewReport` factory pattern.
- Updated `docker-entrypoint.sh` to require and pass through a new `--strategies` flag (same pattern as `--api-key`).
- Updated `README.md`'s backtest and Docker sections/examples accordingly, and fixed pre-existing flag-name mismatches in the CLI example.
- Fixed a `.gitignore` bug where the unanchored `indicator-backtest` binary-ignore pattern was also matching the `cmd/indicator-backtest/` source directory, hiding new source files from git.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manually ran `-list-strategies`, the no-strategies error path, and the unknown-strategy-name error path
- [ ] Docker image build/run (not exercised in this session)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CQ8gWkzAx24J2CdHxFYwuL