### PR TITLE
fix: Wire mcp/ module into lint/test/fmt CI tasks

### DIFF
--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/mark3labs/mcp-go v0.31.0
 )
 
+replace github.com/cinar/indicator/v2 => ../
+
 require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -18,6 +18,8 @@ tasks:
   fmt:
     cmds:
       - go fix ./...
+      - cmd: go fix ./...
+        dir: mcp
 
   lint:
     cmds:
@@ -25,10 +27,20 @@ tasks:
       - go run github.com/securego/gosec/v2/cmd/gosec@v2.20.0 $INDICATOR_BASE
       - go run honnef.co/go/tools/cmd/staticcheck@v0.5.1 $INDICATOR_BASE
       - go run github.com/mgechev/revive@v1.3.4 -config=revive.toml $INDICATOR_BASE
+      - cmd: go vet ./...
+        dir: mcp
+      - cmd: go run github.com/securego/gosec/v2/cmd/gosec@v2.20.0 ./...
+        dir: mcp
+      - cmd: go run honnef.co/go/tools/cmd/staticcheck@v0.5.1 ./...
+        dir: mcp
+      - cmd: go run github.com/mgechev/revive@v1.3.4 -config=../revive.toml ./...
+        dir: mcp
 
   test:
     cmds:
       - go test -race -cover -coverprofile=coverage.out $INDICATOR_BASE
+      - cmd: go test -race -cover -coverprofile=coverage.out ./...
+        dir: mcp
 
   docs:
     cmds:


### PR DESCRIPTION
Fixes #399.

## Summary

Wire mcp/ module into lint/test/fmt CI tasks

## Validation

- Mechanical gate: +14/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->