### PR TITLE
Fix asset sync treating any LastDate error as not-yet-synced

### DIFF
--- a/asset/file_system_repository.go
+++ b/asset/file_system_repository.go
@@ -5,7 +5,6 @@
 package asset
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -86,7 +85,7 @@ func (r *FileSystemRepository) LastDate(name string) (time.Time, error) {
 
 	snapshot, ok := <-helper.Last(snapshots, 1)
 	if !ok {
-		return last, errors.New("empty asset")
+		return last, ErrRepositoryAssetEmpty
 	}
 
 	return snapshot.Date, nil

--- a/asset/file_system_repository_test.go
+++ b/asset/file_system_repository_test.go
@@ -5,7 +5,9 @@
 package asset_test
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"path"
 	"reflect"
 	"testing"
@@ -19,7 +21,7 @@ var repositoryBase = "testdata/repository"
 
 func TestFileSystemRepositoryAssets(t *testing.T) {
 	repository := asset.NewFileSystemRepository(repositoryBase)
-	expected := []string{"brk-b"}
+	expected := []string{"brk-b", "empty"}
 
 	actual, err := repository.Assets()
 	if err != nil {
@@ -109,8 +111,8 @@ func TestFileSystemRepositoryLastDateNonExisting(t *testing.T) {
 	repository := asset.NewFileSystemRepository(repositoryBase)
 
 	_, err := repository.LastDate("brk")
-	if err == nil {
-		t.Fatal("expected error")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected fs.ErrNotExist, got %v", err)
 	}
 }
 
@@ -118,8 +120,8 @@ func TestFileSystemRepositoryLastDateEmpty(t *testing.T) {
 	repository := asset.NewFileSystemRepository(repositoryBase)
 
 	_, err := repository.LastDate("empty")
-	if err == nil {
-		t.Fatal("expected error")
+	if !errors.Is(err, asset.ErrRepositoryAssetEmpty) {
+		t.Fatalf("expected ErrRepositoryAssetEmpty, got %v", err)
 	}
 }
 

--- a/asset/sql_repository.go
+++ b/asset/sql_repository.go
@@ -167,7 +167,7 @@ func (s *SQLRepository) LastDate(name string) (time.Time, error) {
 	err := row.Scan(&date)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return date, fmt.Errorf("unable to find asset")
+			return date, ErrRepositoryAssetNotFound
 		}
 
 		return date, fmt.Errorf("unable to get the last date: %w", err)

--- a/asset/sql_repository_test.go
+++ b/asset/sql_repository_test.go
@@ -90,9 +90,43 @@ func (d *mockRepoDriverAppendErr) Open(name string) (driver.Conn, error) {
 	return &mockRepoConnAppendErr{}, nil
 }
 
+type mockRepoRowsEmpty struct{}
+
+func (r *mockRepoRowsEmpty) Columns() []string              { return []string{"Date"} }
+func (r *mockRepoRowsEmpty) Close() error                   { return nil }
+func (r *mockRepoRowsEmpty) Next(dest []driver.Value) error { return io.EOF }
+
+type mockRepoStmtNoRows struct{}
+
+func (s *mockRepoStmtNoRows) Close() error                                    { return nil }
+func (s *mockRepoStmtNoRows) NumInput() int                                   { return -1 }
+func (s *mockRepoStmtNoRows) Exec(args []driver.Value) (driver.Result, error) { return nil, nil }
+func (s *mockRepoStmtNoRows) Query(args []driver.Value) (driver.Rows, error) {
+	return &mockRepoRowsEmpty{}, nil
+}
+
+type mockRepoConnLastDateNoRows struct{}
+
+func (c *mockRepoConnLastDateNoRows) Prepare(query string) (driver.Stmt, error) {
+	if query == "LASTDATE" {
+		return &mockRepoStmtNoRows{}, nil
+	}
+
+	return &mockRepoStmt{}, nil
+}
+func (c *mockRepoConnLastDateNoRows) Close() error              { return nil }
+func (c *mockRepoConnLastDateNoRows) Begin() (driver.Tx, error) { return nil, nil }
+
+type mockRepoDriverLastDateNoRows struct{}
+
+func (d *mockRepoDriverLastDateNoRows) Open(name string) (driver.Conn, error) {
+	return &mockRepoConnLastDateNoRows{}, nil
+}
+
 func init() {
 	sql.Register("mockrepo", &mockRepoDriver{})
 	sql.Register("mockrepoappenderr", &mockRepoDriverAppendErr{})
+	sql.Register("mockrepolastdatenorows", &mockRepoDriverLastDateNoRows{})
 }
 
 func TestSQLRepository(t *testing.T) {
@@ -158,6 +192,20 @@ func TestSQLRepositoryGetSinceSkipsScanErrors(t *testing.T) {
 
 	if count != 0 {
 		t.Fatalf("expected 0 snapshots, got %d", count)
+	}
+}
+
+func TestSQLRepositoryLastDateNoRows(t *testing.T) {
+	dialect := &mockDialect{}
+	repo, err := asset.NewSQLRepository("mockrepolastdatenorows", "db", dialect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repo.Close()
+
+	_, err = repo.LastDate("TEST")
+	if !errors.Is(err, asset.ErrRepositoryAssetNotFound) {
+		t.Fatalf("expected ErrRepositoryAssetNotFound, got %v", err)
 	}
 }
 

--- a/asset/sync.go
+++ b/asset/sync.go
@@ -6,6 +6,7 @@ package asset
 
 import (
 	"errors"
+	"io/fs"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -75,10 +76,19 @@ func (s *Sync) Run(source, target Repository, defaultStartDate time.Time) error 
 
 			for name := range jobs {
 				lastDate, err := target.LastDate(name)
-				if err == nil {
+
+				switch {
+				case err == nil:
 					lastDate = lastDate.AddDate(0, 0, 1)
-				} else {
+
+				case errors.Is(err, ErrRepositoryAssetNotFound), errors.Is(err, ErrRepositoryAssetEmpty), errors.Is(err, fs.ErrNotExist):
+					// Asset has genuinely never been synced before.
 					lastDate = defaultStartDate
+
+				default:
+					s.Logger.Error("LastDate failed.", "asset", name, "error", err)
+					hasErrors.Store(true)
+					continue
 				}
 
 				s.Logger.Info("Syncing asset.", "asset", name, "start", lastDate.Format("2006-01-02"))

--- a/asset/sync_test.go
+++ b/asset/sync_test.go
@@ -163,6 +163,96 @@ func TestSyncFailingTargetAppendMultiWorker(t *testing.T) {
 	}
 }
 
+func TestSyncLastDateRealErrorDoesNotFallBackToDefault(t *testing.T) {
+	name := "A"
+
+	var getSinceCalledWithDate time.Time
+	getSinceCalled := false
+
+	source := &MockRepository{
+		GetSinceFunc: func(_ string, date time.Time) (<-chan *asset.Snapshot, error) {
+			getSinceCalled = true
+			getSinceCalledWithDate = date
+
+			return helper.SliceToChan([]*asset.Snapshot{}), nil
+		},
+	}
+
+	target := &MockRepository{
+		AssetsFunc: func() ([]string, error) {
+			return []string{name}, nil
+		},
+
+		LastDateFunc: func(_ string) (time.Time, error) {
+			return time.Time{}, errors.New("db connection dropped")
+		},
+
+		AppendFunc: func(_ string, snapshots <-chan *asset.Snapshot) error {
+			helper.Drain(snapshots)
+			return nil
+		},
+	}
+
+	defaultStartDate := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	sync := asset.NewSync()
+	sync.Workers = 1
+	sync.Delay = 0
+
+	err := sync.Run(source, target, defaultStartDate)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if getSinceCalled {
+		t.Fatalf("expected GetSince to not be called, but it was called with date %v", getSinceCalledWithDate)
+	}
+}
+
+func TestSyncLastDateSentinelErrorFallsBackToDefault(t *testing.T) {
+	name := "A"
+
+	var getSinceCalledWithDate time.Time
+
+	source := &MockRepository{
+		GetSinceFunc: func(_ string, date time.Time) (<-chan *asset.Snapshot, error) {
+			getSinceCalledWithDate = date
+
+			return helper.SliceToChan([]*asset.Snapshot{}), nil
+		},
+	}
+
+	target := &MockRepository{
+		AssetsFunc: func() ([]string, error) {
+			return []string{name}, nil
+		},
+
+		LastDateFunc: func(_ string) (time.Time, error) {
+			return time.Time{}, asset.ErrRepositoryAssetEmpty
+		},
+
+		AppendFunc: func(_ string, snapshots <-chan *asset.Snapshot) error {
+			helper.Drain(snapshots)
+			return nil
+		},
+	}
+
+	defaultStartDate := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	sync := asset.NewSync()
+	sync.Workers = 1
+	sync.Delay = 0
+
+	err := sync.Run(source, target, defaultStartDate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !getSinceCalledWithDate.Equal(defaultStartDate) {
+		t.Fatalf("expected GetSince to be called with default start date %v, got %v", defaultStartDate, getSinceCalledWithDate)
+	}
+}
+
 func TestSyncFailingTargetAppend(t *testing.T) {
 	source := &MockRepository{
 		GetSinceFunc: func(_ string, _ time.Time) (<-chan *asset.Snapshot, error) {

--- a/asset/testdata/repository/empty.csv
+++ b/asset/testdata/repository/empty.csv
@@ -1,0 +1,1 @@
+Date,Open,High,Low,Close,Adj Close,Volume


### PR DESCRIPTION
## Summary
- `Sync.Run` treated any error from `target.LastDate(name)` identically to the "asset genuinely never synced" case, silently falling back to `defaultStartDate`. A real failure (DB connection dropped, permission error, unsupported operation from a remote source) looked exactly like "brand new asset," and re-appending full history on top of existing data is risky since `Append` has no dedup.
- Fixed by distinguishing sentinel "no prior data" errors (`ErrRepositoryAssetNotFound`, `ErrRepositoryAssetEmpty`, and `fs.ErrNotExist` for a missing CSV file) from any other error. Only the former fall back to `defaultStartDate`; any other error is now logged via `s.Logger.Error`, counted via `hasErrors.Store(true)`, and that asset is skipped (`continue`) instead of being resynced from the wrong date.
- `FileSystemRepository.LastDate` now returns the sentinel `ErrRepositoryAssetEmpty` instead of a local `errors.New("empty asset")` for the zero-snapshots case, so it can be matched with `errors.Is`. The missing-file case already surfaces as `*fs.PathError` wrapping `fs.ErrNotExist` via `os.Open` inside `helper.ReadFromCsvFile`, so `sync.go` matches on `fs.ErrNotExist` directly — no additional wrapping needed in `FileSystemRepository`.
- `SQLRepository.LastDate` now returns the sentinel `ErrRepositoryAssetNotFound` instead of a local `fmt.Errorf("unable to find asset")` when `sql.ErrNoRows` is hit.
- `TiingoRepository.LastDate` is untouched — it has no explicit "not found" case, so any error it returns already falls into the "real failure" branch, which is correct (network/API failures should not be treated as "not yet synced").

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l asset/` (clean)
- [x] `go test ./...` (all packages pass)
- [x] Added `TestSyncLastDateRealErrorDoesNotFallBackToDefault` and `TestSyncLastDateSentinelErrorFallsBackToDefault` in `asset/sync_test.go`, verifying `GetSince` is/isn't called with `defaultStartDate` depending on the error type from `LastDate`.
- [x] Added `TestSQLRepositoryLastDateNoRows` in `asset/sql_repository_test.go` asserting `errors.Is(err, asset.ErrRepositoryAssetNotFound)`.
- [x] Updated `TestFileSystemRepositoryLastDateNonExisting` (now asserts `errors.Is(err, fs.ErrNotExist)`) and `TestFileSystemRepositoryLastDateEmpty` (now asserts `errors.Is(err, asset.ErrRepositoryAssetEmpty)`, using a new `testdata/repository/empty.csv` fixture with a header row and no data rows so the "empty" case is actually exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp