### PR TITLE
Fix APO ignoring FastSmoothing/SlowSmoothing configuration

### DIFF
--- a/trend/apo.go
+++ b/trend/apo.go
@@ -76,11 +76,13 @@ func (apo *Apo[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T 
 
 	fastEma := NewEma[T]()
 	fastEma.Period = apo.FastPeriod
+	fastEma.Smoothing = apo.FastSmoothing
 	cs[0] = fastEma.ComputeWithContext(ctx, cs[0])
 	cs[0] = helper.SkipWithContext(ctx, cs[0], apo.SlowPeriod-apo.FastPeriod)
 
 	slowEma := NewEma[T]()
 	slowEma.Period = apo.SlowPeriod
+	slowEma.Smoothing = apo.SlowSmoothing
 	cs[1] = slowEma.ComputeWithContext(ctx, cs[1])
 
 	return helper.SubtractWithContext(ctx, cs[0], cs[1])

--- a/trend/apo_test.go
+++ b/trend/apo_test.go
@@ -35,3 +35,44 @@ func TestApo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestApoWithCustomSmoothing(t *testing.T) {
+	type ApoData struct {
+		Close float64
+		Apo   float64
+	}
+
+	input, err := helper.ReadFromCsvFile[ApoData]("testdata/apo.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputs := helper.Duplicate(input, 3)
+	actualClosing := helper.Map(inputs[0], func(a *ApoData) float64 { return a.Close })
+	fastClosing := helper.Map(inputs[1], func(a *ApoData) float64 { return a.Close })
+	slowClosing := helper.Map(inputs[2], func(a *ApoData) float64 { return a.Close })
+
+	apo := trend.NewApo[float64]()
+	apo.FastSmoothing = 1.5
+	apo.SlowSmoothing = 2.5
+	actual := helper.RoundDigits(apo.Compute(actualClosing), 2)
+
+	// Compute the expected APO independently, mirroring Apo's Fast - Slow
+	// composition, to confirm the custom smoothing values are honored.
+	fastEma := trend.NewEma[float64]()
+	fastEma.Period = apo.FastPeriod
+	fastEma.Smoothing = apo.FastSmoothing
+	fast := helper.Skip(fastEma.Compute(fastClosing), apo.SlowPeriod-apo.FastPeriod)
+
+	slowEma := trend.NewEma[float64]()
+	slowEma.Period = apo.SlowPeriod
+	slowEma.Smoothing = apo.SlowSmoothing
+	slow := slowEma.Compute(slowClosing)
+
+	expected := helper.RoundDigits(helper.Subtract(fast, slow), 2)
+
+	err = helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- `Apo[T].ComputeWithContext` built `fastEma`/`slowEma` and only set `.Period` on each, never copying over `apo.FastSmoothing`/`apo.SlowSmoothing`. Both EMAs silently fell back to `Ema`'s own default smoothing constant, so customizing `apo.FastSmoothing`/`apo.SlowSmoothing` (as documented) had no effect.
- Fix: assign `fastEma.Smoothing = apo.FastSmoothing` and `slowEma.Smoothing = apo.SlowSmoothing` right after setting the periods.
- Added `TestApoWithCustomSmoothing`, which sets non-default smoothing values and independently recomputes the expected Fast/Slow EMA subtraction to confirm the fields are now honored. Existing `TestApo` (default smoothing) is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no touched files listed)
- [x] `go test ./...`

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp