### PR TITLE
Fix HTML report sort truncating outcomes and panicking

### DIFF
--- a/backtest/html_report.go
+++ b/backtest/html_report.go
@@ -5,6 +5,8 @@
 package backtest
 
 import (
+	"cmp"
+
 	// Go embed report template.
 	_ "embed"
 	"fmt"
@@ -166,14 +168,18 @@ func (h *HTMLReport) AssetEnd(name string) error {
 
 	// Sort the backtest results by the outcomes.
 	slices.SortFunc(results, func(a, b *htmlReportResult) int {
-		return int(b.Outcome - a.Outcome)
+		return cmp.Compare(b.Outcome, a.Outcome)
 	})
 
-	bestResult := results[0]
+	if len(results) == 0 {
+		h.Logger.Warn("No strategy results for asset, skipping best result.", "asset", name)
+	} else {
+		bestResult := results[0]
 
-	// Report the best result for the current asset.
-	h.Logger.Info("Best outcome", "asset", name, "strategy", bestResult.StrategyName, "outcome", bestResult.Outcome)
-	h.bestResults = append(h.bestResults, bestResult)
+		// Report the best result for the current asset.
+		h.Logger.Info("Best outcome", "asset", name, "strategy", bestResult.StrategyName, "outcome", bestResult.Outcome)
+		h.bestResults = append(h.bestResults, bestResult)
+	}
 
 	// Write the asset report.
 	err := h.writeAssetReport(name, results)
@@ -188,7 +194,7 @@ func (h *HTMLReport) AssetEnd(name string) error {
 func (h *HTMLReport) End() error {
 	// Sort the best results by the outcomes.
 	slices.SortFunc(h.bestResults, func(a, b *htmlReportResult) int {
-		return int(b.Outcome - a.Outcome)
+		return cmp.Compare(b.Outcome, a.Outcome)
 	})
 
 	return h.writeReport()

--- a/backtest/html_report_test.go
+++ b/backtest/html_report_test.go
@@ -7,6 +7,7 @@ package backtest_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cinar/indicator/v2/asset"
@@ -125,6 +126,108 @@ func TestHTMLReportErrors(t *testing.T) {
 	err = report.AssetEnd("UNKNOWN")
 	if err == nil {
 		t.Fatal("expected error for not begun asset")
+	}
+}
+
+func TestHTMLReportSortsCloseOutcomes(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "report_sort")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer helper.RemoveAll(t, outputDir)
+
+	report := backtest.NewHTMLReport(outputDir)
+	report.WriteStrategyReports = false
+
+	strategies := []strategy.Strategy{
+		strategy.NewMajorityStrategy("Strategy A"),
+		strategy.NewMajorityStrategy("Strategy B"),
+	}
+
+	err = report.Begin([]string{"TEST"}, strategies)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = report.AssetBegin("TEST", strategies)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Outcomes 1.2 and 1.6 (0.012 and 0.016 before the *100 scaling in
+	// Write) differ by less than 1.0, so int(b-a) truncation would treat
+	// them as equal. They must still sort with the 1.6 outcome first.
+	writeOutcome := func(currentStrategy strategy.Strategy, outcome float64) {
+		snapshots := make(chan *asset.Snapshot, 1)
+		snapshots <- &asset.Snapshot{Close: 100}
+		close(snapshots)
+
+		actions := make(chan strategy.Action, 1)
+		actions <- strategy.Buy
+		close(actions)
+
+		outcomes := make(chan float64, 1)
+		outcomes <- outcome
+		close(outcomes)
+
+		err = report.Write("TEST", currentStrategy, snapshots, actions, outcomes)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeOutcome(strategies[0], 0.012)
+	writeOutcome(strategies[1], 0.016)
+
+	err = report.AssetEnd("TEST")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = report.End()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "TEST.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	indexA := strings.Index(string(content), "Strategy A")
+	indexB := strings.Index(string(content), "Strategy B")
+	if indexA == -1 || indexB == -1 {
+		t.Fatalf("expected both strategies in report, got: %s", content)
+	}
+
+	if indexB > indexA {
+		t.Fatalf("expected higher outcome (Strategy B, 1.6) to be listed before lower outcome (Strategy A, 1.2)")
+	}
+}
+
+func TestHTMLReportAssetEndNoResults(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "report_no_results")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer helper.RemoveAll(t, outputDir)
+
+	report := backtest.NewHTMLReport(outputDir)
+
+	err = report.AssetBegin("TEST", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No strategies were written for the asset, so AssetEnd must not panic
+	// on an empty results slice.
+	err = report.AssetEnd("TEST")
+	if err != nil {
+		t.Fatalf("expected no error for asset with no results, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "TEST.html")); os.IsNotExist(err) {
+		t.Fatal("TEST.html not found")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `AssetEnd`/`End` in `backtest/html_report.go` sorted results with `int(b.Outcome - a.Outcome)`, which truncates toward zero and treats any two outcomes differing by less than 1.0 as equal, producing an unstable/wrong sort. Replaced with `cmp.Compare(b.Outcome, a.Outcome)` at both call sites.
- `AssetEnd` indexed `results[0]` right after sorting, which panics if an asset had zero recorded strategy results. This is reachable: `AssetBegin` can be called with an empty/nil strategy list (a supported configuration elsewhere, e.g. `strategy.AndStrategy`'s zero-strategies constructor), and if `Write` is never called for that asset before `AssetEnd`, `results` is empty. Fixed by guarding the empty case: log a warning and skip recording a best result instead of erroring, since a zero-strategy asset isn't a caller mistake (unlike the existing `!ok` early-return for an asset that never called `AssetBegin`), and continue writing the (empty) asset report.

## Test plan
- Added `TestHTMLReportSortsCloseOutcomes`, which writes two results with outcomes 1.2 and 1.6 (which would previously tie under `int(...)` truncation) and asserts the higher outcome is listed first in the generated asset report.
- Added `TestHTMLReportAssetEndNoResults`, which calls `AssetBegin` then `AssetEnd` with no `Write` in between, exercising the empty-results path and asserting no panic/error and that the asset report is still written.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (no touched files reported), and `go test ./...` all pass.