### PR TITLE
Fix CountActions hang on zero strategies

### DIFF
--- a/strategy/action.go
+++ b/strategy/action.go
@@ -107,6 +107,10 @@ func DenormalizeActions(ac <-chan Action) <-chan Action {
 
 // CountActions taken a slice of Action channels, and counts them by their type.
 func CountActions(acs []<-chan Action) (int, int, int, bool) {
+	if len(acs) == 0 {
+		return 0, 0, 0, false
+	}
+
 	var buy, hold, sell int
 
 	for _, ac := range acs {

--- a/strategy/action_test.go
+++ b/strategy/action_test.go
@@ -119,6 +119,14 @@ func TestCountActionsEmpty(t *testing.T) {
 	}
 }
 
+func TestCountActionsNoChannels(t *testing.T) {
+	_, _, _, ok := strategy.CountActions([]<-chan strategy.Action{})
+
+	if ok {
+		t.Fatal("is ok")
+	}
+}
+
 func TestCountTransactions(t *testing.T) {
 	actions := helper.SliceToChan([]strategy.Action{strategy.Hold, strategy.Buy, strategy.Hold, strategy.Sell})
 	expected := helper.SliceToChan([]int{0, 1, 1, 2})

--- a/strategy/and_strategy_test.go
+++ b/strategy/and_strategy_test.go
@@ -6,6 +6,7 @@ package strategy_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/asset"
 	"github.com/cinar/indicator/v2/helper"
@@ -53,6 +54,22 @@ func TestAndStrategyReport(t *testing.T) {
 	err = report.WriteToFile(fileName)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAndStrategyNoStrategies(t *testing.T) {
+	snapshots := helper.SliceToChan([]*asset.Snapshot{})
+
+	and := strategy.NewAndStrategy("And Strategy")
+	actual := and.Compute(snapshots)
+
+	select {
+	case _, ok := <-actual:
+		if ok {
+			t.Fatal("expected closed channel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout - result channel never closed")
 	}
 }
 

--- a/strategy/majority_strategy_test.go
+++ b/strategy/majority_strategy_test.go
@@ -6,11 +6,12 @@ package strategy_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/asset"
+	"github.com/cinar/indicator/v2/examples/trend"
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/strategy"
-	"github.com/cinar/indicator/v2/examples/trend"
 )
 
 func TestMajorityStrategy(t *testing.T) {
@@ -34,6 +35,22 @@ func TestMajorityStrategy(t *testing.T) {
 	err = helper.CheckEquals(actual, expected)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMajorityStrategyNoStrategies(t *testing.T) {
+	snapshots := helper.SliceToChan([]*asset.Snapshot{})
+
+	majority := strategy.NewMajorityStrategy("Majority Strategy")
+	actual := majority.Compute(snapshots)
+
+	select {
+	case _, ok := <-actual:
+		if ok {
+			t.Fatal("expected closed channel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout - result channel never closed")
 	}
 }
 

--- a/strategy/or_strategy_test.go
+++ b/strategy/or_strategy_test.go
@@ -6,11 +6,12 @@ package strategy_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/asset"
+	"github.com/cinar/indicator/v2/examples/trend"
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/strategy"
-	"github.com/cinar/indicator/v2/examples/trend"
 )
 
 func TestOrStrategy(t *testing.T) {
@@ -34,6 +35,22 @@ func TestOrStrategy(t *testing.T) {
 	err = helper.CheckEquals(actual, expected)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestOrStrategyNoStrategies(t *testing.T) {
+	snapshots := helper.SliceToChan([]*asset.Snapshot{})
+
+	or := strategy.NewOrStrategy("Or Strategy")
+	actual := or.Compute(snapshots)
+
+	select {
+	case _, ok := <-actual:
+		if ok {
+			t.Fatal("expected closed channel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout - result channel never closed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `CountActions` returned `(0, 0, 0, true)` for a zero-length channel slice because its `for` loop body never executes on an empty slice, so `ok` fell through to `true` instead of signaling completion.
- `AndStrategy`, `OrStrategy`, and `MajorityStrategy` all loop on `CountActions(sources) ... if !ok { break }` with no `ctx.Done()` check, so with zero child strategies (`sources` is an empty slice) they would spin forever, `AndStrategy` sending `Sell` on every iteration, and their `result` channel would never close — an uninterruptible infinite loop / goroutine leak once nothing reads `result`.
- Fixed at the shared root cause: `CountActions` now returns `ok=false` immediately when `len(acs) == 0`, which fixes all three consumers without touching their constructors.

## Test plan
- Added `TestCountActionsNoChannels` in `strategy/action_test.go` asserting `CountActions([]<-chan Action{})` returns `ok=false` (distinct from the existing `TestCountActionsEmpty`, which tests three pre-closed channels rather than a zero-length slice).
- Added `TestAndStrategyNoStrategies`, `TestOrStrategyNoStrategies`, `TestMajorityStrategyNoStrategies` constructing each strategy with zero child strategies and confirming `Compute`'s result channel closes within 2s instead of hanging.
- Verified all four new tests fail (by temporarily reverting the `CountActions` fix) before the fix, and pass after.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (no touched files listed), and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp