### PR TITLE
Fix InMemoryRepository storage map race

### DIFF
--- a/asset/in_memory_repository.go
+++ b/asset/in_memory_repository.go
@@ -5,14 +5,18 @@
 package asset
 
 import (
+	"sync"
 	"time"
 
 	"github.com/cinar/indicator/v2/helper"
 )
 
 // InMemoryRepository stores and retrieves asset snapshots using
-// an in memory storage.
+// an in memory storage. It is safe for concurrent use.
 type InMemoryRepository struct {
+	// mutex guards access to storage.
+	mutex sync.RWMutex
+
 	// storage is the in memory storage for assets.
 	storage map[string][]*Snapshot
 }
@@ -26,6 +30,9 @@ func NewInMemoryRepository() *InMemoryRepository {
 
 // Assets returns the names of all assets in the repository.
 func (r *InMemoryRepository) Assets() ([]string, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
 	assets := make([]string, 0, len(r.storage))
 	for name := range r.storage {
 		assets = append(assets, name)
@@ -36,12 +43,21 @@ func (r *InMemoryRepository) Assets() ([]string, error) {
 
 // Get attempts to return a channel of snapshots for the asset with the given name.
 func (r *InMemoryRepository) Get(name string) (<-chan *Snapshot, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
 	snapshots, ok := r.storage[name]
 	if !ok {
 		return nil, ErrRepositoryAssetNotFound
 	}
 
-	return helper.SliceToChan(snapshots), nil
+	// Copy while holding the lock, since SliceToChan reads the slice
+	// lazily from a goroutine, after a concurrent Append may have
+	// mutated this slice's backing array in place.
+	copied := make([]*Snapshot, len(snapshots))
+	copy(copied, snapshots)
+
+	return helper.SliceToChan(copied), nil
 }
 
 // GetSince attempts to return a channel of snapshots for the asset with the given name since the given date.
@@ -77,13 +93,16 @@ func (r *InMemoryRepository) LastDate(name string) (time.Time, error) {
 
 // Append adds the given snapshows to the asset with the given name.
 func (r *InMemoryRepository) Append(name string, snapshots <-chan *Snapshot) error {
-	combined := r.storage[name]
+	var newSnapshots []*Snapshot
 
 	for snapshot := range snapshots {
-		combined = append(combined, snapshot)
+		newSnapshots = append(newSnapshots, snapshot)
 	}
 
-	r.storage[name] = combined
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.storage[name] = append(r.storage[name], newSnapshots...)
 
 	return nil
 }

--- a/asset/in_memory_repository_test.go
+++ b/asset/in_memory_repository_test.go
@@ -5,6 +5,8 @@
 package asset_test
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -157,4 +159,58 @@ func TestInMemoryRepositoryLastDate(t *testing.T) {
 	if !expected.Equal(actual) {
 		t.Fatalf("actual %v expected %v", actual, expected)
 	}
+}
+
+func TestInMemoryRepositoryConcurrentAccess(t *testing.T) {
+	repository := asset.NewInMemoryRepository()
+
+	const (
+		workers        = 8
+		appendsPerName = 50
+	)
+
+	var wg sync.WaitGroup
+
+	for w := 0; w < workers; w++ {
+		name := fmt.Sprintf("ASSET_%d", w)
+
+		wg.Add(2)
+
+		// Concurrently appends snapshots to the same asset name.
+		go func(name string) {
+			defer wg.Done()
+
+			for i := 0; i < appendsPerName; i++ {
+				snapshot := &asset.Snapshot{
+					Date: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i),
+				}
+
+				err := repository.Append(name, helper.SliceToChan([]*asset.Snapshot{snapshot}))
+				if err != nil {
+					t.Error(err)
+				}
+			}
+		}(name)
+
+		// Concurrently reads the storage while the appends above are in flight.
+		go func(name string) {
+			defer wg.Done()
+
+			for i := 0; i < appendsPerName; i++ {
+				if _, err := repository.Assets(); err != nil {
+					t.Error(err)
+				}
+
+				channel, err := repository.Get(name)
+				if err != nil {
+					continue
+				}
+
+				for range channel {
+				}
+			}
+		}(name)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- `InMemoryRepository.storage` had no synchronization: `Append` writes and `Assets`/`Get`/`GetSince`/`LastDate` reads on the map raced, which can crash the process with `fatal error: concurrent map read and write`. This is realistic because `InMemoryRepository` is used directly and via `asset.Sync`, which explicitly supports multiple concurrent `Workers`.
- Added a `sync.RWMutex` guarding all access to `storage`: `Append` takes a full lock for the read-modify-write; `Assets`, `Get`, and `GetSince`/`LastDate` (which call `Get`) take a read lock.
- Handled the subtler hazard beyond the map itself: `helper.SliceToChan` reads its input slice lazily from a background goroutine rather than up front, so a concurrent `Append`'s in-place `append` (when the backing array has spare capacity) could still mutate the slice contents while `Get`'s consumer was iterating it. `Get` now copies the snapshot slice while still holding the read lock, before handing it to `SliceToChan`, so it's safe.
- Scoped to `InMemoryRepository` only — `FileSystemRepository`, `SQLRepository`, and `TiingoRepository` are untouched.

## Test plan
- Added `TestInMemoryRepositoryConcurrentAccess`, which runs concurrent `Append` and `Get`/`Assets` calls across multiple goroutines/asset names.
- Verified the new test actually catches the bug: temporarily reverted the fix (`in_memory_repository.go`) and confirmed `go test -race -run TestInMemoryRepositoryConcurrentAccess ./asset/...` reliably reports `WARNING: DATA RACE` and fails; reapplied the fix and confirmed it passes.
- `go build ./...` — passes
- `go vet ./...` — passes
- `gofmt -l .` — no touched files listed (pre-existing unformatted files elsewhere in the repo are unrelated to this change)
- `go test ./...` — passes
- `go test -race ./asset/...` — passes