### PR TITLE
Fix Gcd/Lcm panicking on empty/zero input, bad negatives

### DIFF
--- a/helper/gcd.go
+++ b/helper/gcd.go
@@ -4,12 +4,18 @@
 
 package helper
 
-// Gcd calculates the Greatest Common Divisor of the given numbers.
+// Gcd calculates the Greatest Common Divisor of the given numbers. It
+// returns 0 for empty input, and treats negative values as their
+// absolute value, since GCD is conventionally non-negative.
 func Gcd(values ...int) int {
-	gcd := values[0]
+	if len(values) == 0 {
+		return 0
+	}
+
+	gcd := abs(values[0])
 
 	for i := 1; i < len(values); i++ {
-		value := values[i]
+		value := abs(values[i])
 
 		for value > 0 {
 			gcd, value = value, gcd%value
@@ -21,4 +27,13 @@ func Gcd(values ...int) int {
 	}
 
 	return gcd
+}
+
+// abs returns the absolute value of the given int.
+func abs(value int) int {
+	if value < 0 {
+		return -value
+	}
+
+	return value
 }

--- a/helper/gcd_test.go
+++ b/helper/gcd_test.go
@@ -36,3 +36,30 @@ func TestGcdWithFourValues(t *testing.T) {
 		t.Fatalf("actual %d expected %d", actual, expected)
 	}
 }
+
+func TestGcdWithEmptyInput(t *testing.T) {
+	actual := helper.Gcd()
+	expected := 0
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+func TestGcdWithOneNegativeValue(t *testing.T) {
+	actual := helper.Gcd(10, -5)
+	expected := 5
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+func TestGcdWithTwoNegativeValues(t *testing.T) {
+	actual := helper.Gcd(-10, -5)
+	expected := 5
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}

--- a/helper/lcm.go
+++ b/helper/lcm.go
@@ -4,12 +4,23 @@
 
 package helper
 
-// Lcm calculates the Least Common Multiple of the given numbers.
+// Lcm calculates the Least Common Multiple of the given numbers. It
+// returns 0 for empty input, and returns 0 whenever 0 is among the
+// values, matching the convention that LCM involving 0 is 0.
 func Lcm(values ...int) int {
+	if len(values) == 0 {
+		return 0
+	}
+
 	lcm := values[0]
 
 	for i := 1; i < len(values); i++ {
-		lcm = (values[i] * lcm) / Gcd(values[i], lcm)
+		if lcm == 0 || values[i] == 0 {
+			return 0
+		}
+
+		// Divide before multiplying to reduce the risk of int overflow.
+		lcm = values[i] / Gcd(values[i], lcm) * lcm
 	}
 
 	return lcm

--- a/helper/lcm_test.go
+++ b/helper/lcm_test.go
@@ -36,3 +36,44 @@ func TestLcmWithFiveValues(t *testing.T) {
 		t.Fatalf("actual %d expected %d", actual, expected)
 	}
 }
+
+func TestLcmWithEmptyInput(t *testing.T) {
+	actual := helper.Lcm()
+	expected := 0
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+func TestLcmWithZeroInInput(t *testing.T) {
+	actual := helper.Lcm(0, 5)
+	expected := 0
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+func TestLcmWithAllZeros(t *testing.T) {
+	actual := helper.Lcm(0, 0)
+	expected := 0
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+// TestLcmAvoidsMultiplyBeforeDivideOverflow uses values whose product
+// overflows a 64-bit int (16000000016000000000, larger than
+// math.MaxInt64) even though their LCM (4000000004000000000) does not.
+// Computing (values[i]*lcm)/Gcd(...) would overflow and silently wrap
+// to a wrong, negative result; dividing first avoids it.
+func TestLcmAvoidsMultiplyBeforeDivideOverflow(t *testing.T) {
+	actual := helper.Lcm(4000000000, 4000000004)
+	expected := 4000000004000000000
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- `helper.Gcd`/`helper.Lcm` indexed `values[0]` directly and panicked on empty input.
- `Gcd` ignored the sign of negative operands (`Gcd(10, -5)` returned `10` instead of `5`) because the Euclidean loop's `value > 0` check short-circuits on a negative starting value.
- `Lcm` divided by zero once its running accumulator and a subsequent argument were both `0` (e.g. `Lcm(0, 0)`); more generally, any `0` in the input list should mathematically make the LCM `0`, not panic.
- `Lcm`'s `(values[i]*lcm)/Gcd(...)` multiplied before dividing, risking `int` overflow for large inputs; reordered to `values[i]/Gcd(...)*lcm`.

This is dormant code with zero in-tree callers today (`grep -rn "helper.Gcd\|helper.Lcm"` only turns up the package's own tests), but both functions are exported public API, so external callers can hit all of these.

Both functions now return `0` for empty input (consistent with `Lcm`'s existing zero-involving-0 convention) rather than changing their signature to return an error, to keep this a small, low-disruption fix.

## Test plan
- Added tests in `helper/gcd_test.go` for empty input and negative operands (single and both negative).
- Added tests in `helper/lcm_test.go` for empty input, a zero in the list, all zeros, and a large-value case (`Lcm(4000000000, 4000000004)`) whose product overflows `int64` under the old multiply-then-divide ordering (verified it silently wraps to a wrong negative result) but whose actual LCM fits, demonstrating the new divide-then-multiply ordering is required.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (no output), `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp
