### PR TITLE
Fix Ring.At silently returning stale values past fill count

### DIFF
--- a/examples/momentum/triple_rsi_strategy.go
+++ b/examples/momentum/triple_rsi_strategy.go
@@ -130,13 +130,16 @@ func (t *TripleRsiStrategy) ComputeWithContext(ctx context.Context, snapshots <-
 
 		// - The 5-period RSI reading is down for the 3rd period in a row.
 		for i := 1; i < t.DownDays; i++ {
-			if memory.At(i-1) < memory.At(i) {
+			prev, prevOk := memory.At(i - 1)
+			curr, currOk := memory.At(i)
+			if !prevOk || !currOk || prev < curr {
 				return strategy.Hold
 			}
 		}
 
 		// - The 5-period RSI reading was below 60 three trading periods ago.
-		if memory.At(0) >= t.BuySignalAt {
+		signal, signalOk := memory.At(0)
+		if !signalOk || signal >= t.BuySignalAt {
 			return strategy.Hold
 		}
 

--- a/helper/echo.go
+++ b/helper/echo.go
@@ -41,10 +41,15 @@ func EchoWithContext[T any](ctx context.Context, input <-chan T, last, count int
 	repeat:
 		for i := 0; i < count; i++ {
 			for j := 0; j < last; j++ {
+				v, ok := memory.At(j)
+				if !ok {
+					break
+				}
+
 				select {
 				case <-ctx.Done():
 					return
-				case output <- memory.At(j):
+				case output <- v:
 				}
 			}
 		}

--- a/helper/echo_test.go
+++ b/helper/echo_test.go
@@ -21,3 +21,15 @@ func TestEcho(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestEchoShorterThanLast(t *testing.T) {
+	input := helper.SliceToChan([]int{2, 4})
+	expected := helper.SliceToChan([]int{2, 4, 2, 4, 2, 4})
+
+	actual := helper.Echo(input, 5, 2)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/helper/ring.go
+++ b/helper/ring.go
@@ -20,6 +20,7 @@ type Ring[T any] struct {
 	begin  int
 	end    int
 	empty  bool
+	count  int
 }
 
 // NewRing creates a new ring instance with the given size.
@@ -29,6 +30,7 @@ func NewRing[T any](size int) *Ring[T] {
 		begin:  0,
 		end:    0,
 		empty:  true,
+		count:  0,
 	}
 }
 
@@ -37,6 +39,8 @@ func NewRing[T any](size int) *Ring[T] {
 func (r *Ring[T]) Put(t T) T {
 	if r.IsFull() {
 		r.begin = r.nextIndex(r.begin)
+	} else {
+		r.count++
 	}
 
 	o := r.buffer[r.end]
@@ -59,6 +63,7 @@ func (r *Ring[T]) Get() (T, bool) {
 
 	t = r.buffer[r.begin]
 	r.begin = r.nextIndex(r.begin)
+	r.count--
 
 	if r.begin == r.end {
 		r.empty = true
@@ -67,9 +72,17 @@ func (r *Ring[T]) Get() (T, bool) {
 	return t, true
 }
 
-// At returns the value at the given index.
-func (r *Ring[T]) At(index int) T {
-	return r.buffer[(r.begin+index)%len(r.buffer)]
+// At returns the value at the given index, relative to the oldest
+// element currently in the ring. It returns false if index is out
+// of range, or fewer than index+1 elements have ever been Put.
+func (r *Ring[T]) At(index int) (T, bool) {
+	var t T
+
+	if index < 0 || index >= r.count {
+		return t, false
+	}
+
+	return r.buffer[(r.begin+index)%len(r.buffer)], true
 }
 
 // IsEmpty checks if the current ring buffer is empty.

--- a/helper/ring_test.go
+++ b/helper/ring_test.go
@@ -46,8 +46,12 @@ func TestRingEmpty(t *testing.T) {
 			j = size - 1
 		}
 
-		if ring.At(j) != n {
-			t.Fatalf("actual %v expected %v", ring.At(j), n)
+		actual, ok := ring.At(j)
+		if !ok {
+			t.Fatalf("At(%d) not ok", j)
+		}
+		if actual != n {
+			t.Fatalf("actual %v expected %v", actual, n)
 		}
 	}
 
@@ -69,5 +73,46 @@ func TestRingEmpty(t *testing.T) {
 	_, ok := ring.Get()
 	if ok {
 		t.Fatal("not empty")
+	}
+}
+
+func TestRingAtPartiallyFilled(t *testing.T) {
+	ring := helper.NewRing[int](5)
+
+	ring.Put(1)
+	ring.Put(2)
+
+	for i, expected := range []int{1, 2} {
+		actual, ok := ring.At(i)
+		if !ok {
+			t.Fatalf("At(%d) not ok", i)
+		}
+		if actual != expected {
+			t.Fatalf("actual %v expected %v", actual, expected)
+		}
+	}
+
+	for i := 2; i < 5; i++ {
+		if _, ok := ring.At(i); ok {
+			t.Fatalf("At(%d) should not be ok", i)
+		}
+	}
+}
+
+func TestRingAtFull(t *testing.T) {
+	ring := helper.NewRing[int](5)
+
+	for i := 1; i <= 5; i++ {
+		ring.Put(i)
+	}
+
+	for i, expected := range []int{1, 2, 3, 4, 5} {
+		actual, ok := ring.At(i)
+		if !ok {
+			t.Fatalf("At(%d) not ok", i)
+		}
+		if actual != expected {
+			t.Fatalf("actual %v expected %v", actual, expected)
+		}
 	}
 }

--- a/trend/wma.go
+++ b/trend/wma.go
@@ -45,7 +45,10 @@ func (w *Wma[T]) ComputeWithContext(ctx context.Context, values <-chan T) <-chan
 		var sum T
 
 		for i := 0; i < w.Period; i++ {
-			v := window.At(i)
+			v, ok := window.At(i)
+			if !ok {
+				continue
+			}
 			sum += v * T(i+1)
 		}
 

--- a/volatility/moving_std.go
+++ b/volatility/moving_std.go
@@ -65,7 +65,11 @@ func (m *MovingStd[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-cha
 					sum2 := T(0)
 
 					for i := 0; i < m.Period; i++ {
-						sum2 += T(math.Pow(float64(ring.At(i)-sma), 2))
+						v, ok := ring.At(i)
+						if !ok {
+							continue
+						}
+						sum2 += T(math.Pow(float64(v-sma), 2))
 					}
 
 					std := T(math.Sqrt(float64(sum2 / T(m.Period))))


### PR DESCRIPTION
## Summary
- `Ring[T].At(index)` indexed into the underlying buffer with no check on how many elements had actually been `Put`, so a ring that was only partially filled would silently return a never-set zero value for unfilled slots instead of signaling that the data isn't real.
- **Breaking API change:** `Ring[T].At` now returns `(T, bool)` instead of `T`, matching the existing `Get() (T, bool)` pattern. `Ring` gained an internal `count` field to track how many slots are currently populated (incremented on `Put` while not full, decremented on `Get`), and `At` returns `ok=false` when `index` is negative, `>= len(buffer)`, or beyond how many elements have ever been captured.
- Updated all in-tree callers of `.At()` on `Ring` (found via grep, more than the two originally flagged):
  - `helper/echo.go`'s `EchoWithContext` repeat loop — this was the one genuinely reachable bug: if the input stream produced fewer than `last` values before closing, the repeat phase used to pad the tail with zero-valued garbage. It now breaks out of the inner loop as soon as `At` reports `ok=false`, so a shorter-than-`last` input repeats only what was actually captured.
  - `examples/momentum/triple_rsi_strategy.go`, `trend/wma.go`, `volatility/moving_std.go` — all three already guard with `IsFull()`/`!IsFull()` before calling `.At()`, so `ok` should always be `true` in practice, but they're updated to handle `ok=false` defensively (Hold/skip or contribute 0, as appropriate) rather than blindly discarding it.

## Behavior decision for EchoWithContext short input
Chose to repeat whatever was actually captured, rather than fabricating zero values for the never-filled tail. Since the ring's contents don't change across repeat iterations, breaking the inner loop at the first unfilled index naturally reproduces "echo only what arrived" for every repeat pass. Added `TestEchoShorterThanLast` covering a 2-element input with `last=5`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no touched files listed (pre-existing unformatted files elsewhere are unrelated/unchanged)
- [x] `go test ./...` — all packages pass
- [x] New tests: `helper.TestRingAtPartiallyFilled` (5-slot ring, 2 values `Put`, `At(2..4)` returns `ok=false`), `helper.TestRingAtFull`, `helper.TestEchoShorterThanLast`
- [x] `examples/momentum/triple_rsi_strategy_test.go` passes unchanged (uses existing CSV fixtures; behavior unaffected since that caller was already `IsFull()`-guarded)