### PR TITLE
Fix Tiingo body leaks; document SQL GetSince/Get quirks

### DIFF
--- a/asset/repository.go
+++ b/asset/repository.go
@@ -23,10 +23,23 @@ type Repository interface {
 
 	// Get attempts to return a channel of snapshots for
 	// the asset with the given name.
+	//
+	// Some implementations (e.g. SQLRepository, TiingoRepository) only
+	// return snapshots from 2000-01-01 onward by design, while others
+	// (e.g. InMemoryRepository, FileSystemRepository) return full
+	// history with no floor date; see each implementation's doc comment.
 	Get(name string) (<-chan *Snapshot, error)
 
 	// GetSince attempts to return a channel of snapshots for
 	// the asset with the given name since the given date.
+	//
+	// Implementations may run the underlying retrieval in a background
+	// goroutine that sends on the returned channel; there is no
+	// cancellation parameter on this method, so callers must read the
+	// returned channel to completion. Abandoning it partway through can
+	// leak the goroutine and any resources it holds (e.g. a database
+	// connection or an HTTP response body) for implementations that rely
+	// on the channel being drained to release them.
 	GetSince(name string, date time.Time) (<-chan *Snapshot, error)
 
 	// LastDate returns the date of the last snapshot for

--- a/asset/sql_repository.go
+++ b/asset/sql_repository.go
@@ -114,11 +114,24 @@ func (s *SQLRepository) Assets() ([]string, error) {
 }
 
 // Get attempts to return a channel of snapshots for the asset with the given name.
+//
+// By design, this only returns snapshots from 2000-01-01 onward, unlike
+// InMemoryRepository and FileSystemRepository, whose Get returns full
+// history with no floor date.
 func (s *SQLRepository) Get(name string) (<-chan *Snapshot, error) {
 	return s.GetSince(name, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 }
 
 // GetSince attempts to return a channel of snapshots for the asset with the given name since the given date.
+//
+// The query runs in a background goroutine that owns the underlying database
+// rows and sends each scanned snapshot on the returned channel. Callers must
+// drain the returned channel to completion (or otherwise ensure it keeps
+// being read) so the goroutine can finish and its deferred cleanup can
+// release the rows/connection; abandoning the channel partway through leaks
+// the goroutine and the underlying database resources, since there is no
+// cancellation signal on this interface. See Repository.GetSince for the
+// broader interface-level contract.
 func (s *SQLRepository) GetSince(name string, date time.Time) (<-chan *Snapshot, error) {
 	rows, err := s.getSinceQuery.Query(name, date)
 	if err != nil {

--- a/asset/tiingo_repository.go
+++ b/asset/tiingo_repository.go
@@ -12,6 +12,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/cinar/indicator/v2/helper"
 )
 
 // TiingoMeta is the response from the meta endpoint.
@@ -128,6 +130,10 @@ func (*TiingoRepository) Assets() ([]string, error) {
 }
 
 // Get attempts to return a channel of snapshots for the asset with the given name.
+//
+// By design, this only returns snapshots from 2000-01-01 onward, unlike
+// InMemoryRepository and FileSystemRepository, whose Get returns full
+// history with no floor date.
 func (r *TiingoRepository) Get(name string) (<-chan *Snapshot, error) {
 	return r.GetSince(name, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 }
@@ -151,13 +157,22 @@ func (r *TiingoRepository) GetSince(name string, date time.Time) (<-chan *Snapsh
 	}
 
 	if res.StatusCode != 200 {
+		helper.CloseAndLogErrorWithLogger(res.Body, "Unable to close response.", r.Logger)
 		return nil, fmt.Errorf("request failed with %s", res.Status)
 	}
 
 	snapshots := make(chan *Snapshot)
 
 	go func() {
+		// The response body must stay open for as long as this goroutine is
+		// decoding from it, so it is closed here via defer rather than by
+		// the caller, ensuring it is closed exactly once regardless of
+		// which return path below is taken. Deferred close(snapshots) is
+		// declared first so it runs last (defers are LIFO), guaranteeing
+		// the body is already closed by the time a consumer observes the
+		// channel closing.
 		defer close(snapshots)
+		defer helper.CloseAndLogErrorWithLogger(res.Body, "Unable to close response.", r.Logger)
 
 		decoder := json.NewDecoder(res.Body)
 
@@ -182,12 +197,6 @@ func (r *TiingoRepository) GetSince(name string, date time.Time) (<-chan *Snapsh
 		_, err = decoder.Token()
 		if err != nil {
 			r.Logger.Error("GetSince failed.", "error", err)
-			return
-		}
-
-		err = res.Body.Close()
-		if err != nil {
-			r.Logger.Error("Unable to close respose.", "error", err)
 		}
 	}()
 
@@ -209,17 +218,13 @@ func (r *TiingoRepository) LastDate(name string) (time.Time, error) {
 	if err != nil {
 		return lastDate, err
 	}
+	defer helper.CloseAndLogErrorWithLogger(res.Body, "Unable to close response.", r.Logger)
 
 	if res.StatusCode != 200 {
 		return lastDate, fmt.Errorf("request failed with %s", res.Status)
 	}
 
 	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return lastDate, err
-	}
-
-	err = res.Body.Close()
 	if err != nil {
 		return lastDate, err
 	}

--- a/asset/tiingo_repository_internal_test.go
+++ b/asset/tiingo_repository_internal_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package asset
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// closeTrackingBody wraps an io.ReadCloser and records whether Close was called.
+type closeTrackingBody struct {
+	io.ReadCloser
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return b.ReadCloser.Close()
+}
+
+// bodyTrackingTransport wraps a RoundTripper and replaces the last response's
+// body with a closeTrackingBody, so tests can assert it was closed.
+type bodyTrackingTransport struct {
+	base http.RoundTripper
+	body *closeTrackingBody
+}
+
+func (t *bodyTrackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	t.body = &closeTrackingBody{ReadCloser: res.Body}
+	res.Body = t.body
+
+	return res, nil
+}
+
+// TestTiingoRepositoryLastDateClosesBodyOnStatusError verifies that
+// LastDate closes the response body even when it returns early because
+// of a non-200 status code, i.e. before the body is ever read.
+func TestTiingoRepositoryLastDateClosesBodyOnStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer server.Close()
+
+	transport := &bodyTrackingTransport{base: http.DefaultTransport}
+
+	repository := NewTiingoRepository("1234")
+	repository.BaseURL = server.URL
+	repository.client = &http.Client{Transport: transport}
+
+	_, err := repository.LastDate("A")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if transport.body == nil {
+		t.Fatal("expected a tracked response body")
+	}
+
+	if !transport.body.closed {
+		t.Fatal("expected response body to be closed")
+	}
+}
+
+// TestTiingoRepositoryGetSinceClosesBodyOnDecodeError verifies that
+// GetSince's background goroutine closes the response body even when
+// decoding fails on the very first token, one of the early-return paths
+// that previously left the body open.
+func TestTiingoRepositoryGetSinceClosesBodyOnDecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	transport := &bodyTrackingTransport{base: http.DefaultTransport}
+
+	repository := NewTiingoRepository("1234")
+	repository.BaseURL = server.URL
+	repository.client = &http.Client{Transport: transport}
+
+	snapshots, err := repository.GetSince("A", time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain the channel to completion. Because the body is closed via a
+	// defer declared after (and therefore run before) close(snapshots),
+	// observing the channel close here guarantees the body is already
+	// closed.
+	for range snapshots {
+	}
+
+	if transport.body == nil {
+		t.Fatal("expected a tracked response body")
+	}
+
+	if !transport.body.closed {
+		t.Fatal("expected response body to be closed")
+	}
+}


### PR DESCRIPTION
## Summary

Part of a larger triage item on `asset/` repository resource leaks and inconsistencies. Part (a) — `LastDate` returning generic errors instead of sentinel errors — is already fixed in a separate, still-open PR and is out of scope here. This PR covers parts (b) and (c):

**Fixed (real bug, behavior change):**
- `TiingoRepository.LastDate` and `GetSince` leaked the HTTP response body on several early-return paths (non-200 status, read/unmarshal error, decode error, first-token error). Both now close the body via `defer` right after a successful `client.Do()` — for `GetSince` the close is deferred inside the background goroutine (ordered to run before `close(snapshots)`) so the body stays open while still being decoded, but is guaranteed to close exactly once on every return path.
- Added `TestTiingoRepositoryLastDateClosesBodyOnStatusError` and `TestTiingoRepositoryGetSinceClosesBodyOnDecodeError` (new internal test file, since the HTTP client is an unexported field) using a close-tracking `http.RoundTripper` to verify the fix.

**Documented only (no behavior change):**
- `SQLRepository.GetSince` runs its query in a background goroutine sending on an unbuffered channel, only closing the DB rows via `defer` once the goroutine returns. A consumer that stops draining early leaks the goroutine and the DB rows/connection. Every in-tree caller (`asset.Sync`, via `Append` ranging the full channel) already drains to completion, so this is latent rather than currently triggered. Since `Repository` has no context/cancellation parameter, adding one would cascade into all 4 backends and every caller — out of scope here. Fixed with clear doc comments on `Repository.GetSince` and `SQLRepository.GetSince` spelling out the drain requirement, rather than a partial mitigation like a channel buffer that would only delay (not eliminate) the leak for a fully-abandoned channel.
- `SQLRepository.Get`/`TiingoRepository.Get` hardcode a 2000-01-01 floor date while `InMemoryRepository`/`FileSystemRepository` return full history. Flagged as a real but likely-intentional inconsistency; left as-is (changing it could be a real behavioral/performance change) and now documented on both `Get` methods, cross-referenced from `Repository.Get`.

**Left alone:** `InMemoryRepository`, `FileSystemRepository`, `Repository` interface signature, `examples/`, `strategy/`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no touched files listed
- [x] `go test ./...` — all pass
- [x] `go test ./asset/... -race` — no races, including new tests exercising the background goroutine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp