### PR TITLE
Add opt-in NextOpen/NextClose execution timing

### DIFF
--- a/strategy/execution_timing.go
+++ b/strategy/execution_timing.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package strategy
+
+// ExecutionTiming represents when a simulated trade executes relative to the bar its action was computed from.
+type ExecutionTiming int
+
+const (
+	// AtClose executes at the same bar's closing price. This is the existing default behavior used by
+	// OutcomeWithContext and ComputeWithOutcomeWithContext, and assumes the trade fills at the very
+	// close that produced the signal.
+	AtClose ExecutionTiming = iota
+
+	// NextOpen executes at the opening price of the bar immediately following the signal. This is a
+	// more realistic assumption for strategies that can only act after a bar has fully closed.
+	NextOpen
+
+	// NextClose executes at the closing price of the bar immediately following the signal.
+	NextClose
+)
+
+// String returns the string representation of the ExecutionTiming.
+func (e ExecutionTiming) String() string {
+	switch e {
+	case NextOpen:
+		return "NextOpen"
+
+	case NextClose:
+		return "NextClose"
+
+	default:
+		return "AtClose"
+	}
+}

--- a/strategy/execution_timing_test.go
+++ b/strategy/execution_timing_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package strategy_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/asset"
+	"github.com/cinar/indicator/v2/helper"
+	"github.com/cinar/indicator/v2/strategy"
+)
+
+// fixedActionsStrategy is a test double that ignores the snapshot values and emits a
+// predetermined sequence of actions, one per snapshot received. Any snapshot beyond the
+// end of the configured sequence results in Hold.
+type fixedActionsStrategy struct {
+	actions []strategy.Action
+}
+
+func (s *fixedActionsStrategy) Name() string {
+	return "fixedActionsStrategy"
+}
+
+func (s *fixedActionsStrategy) Compute(snapshots <-chan *asset.Snapshot) <-chan strategy.Action {
+	actions := make(chan strategy.Action)
+
+	go func() {
+		defer close(actions)
+
+		i := 0
+		for range snapshots {
+			if i < len(s.actions) {
+				actions <- s.actions[i]
+			} else {
+				actions <- strategy.Hold
+			}
+			i++
+		}
+	}()
+
+	return actions
+}
+
+func (s *fixedActionsStrategy) Report(_ <-chan *asset.Snapshot) *helper.Report {
+	return &helper.Report{}
+}
+
+// executionTimingSnapshots returns a small, hand-picked 4-bar OHLC series where the
+// opening and closing prices differ enough, bar over bar, that AtClose, NextOpen, and
+// NextClose execution timings produce clearly distinct, independently verifiable outcomes.
+func executionTimingSnapshots() <-chan *asset.Snapshot {
+	return helper.SliceToChan([]*asset.Snapshot{
+		{Open: 10, Close: 12},
+		{Open: 13, Close: 11},
+		{Open: 10, Close: 14},
+		{Open: 15, Close: 13},
+	})
+}
+
+// executionTimingActions is Buy on the first bar, Sell on the third bar, Hold otherwise.
+func executionTimingActions() []strategy.Action {
+	return []strategy.Action{strategy.Buy, strategy.Hold, strategy.Sell, strategy.Hold}
+}
+
+// drainActions consumes and discards an actions channel in the background. The actions channel
+// returned alongside outcomes is one branch of an internal Duplicate; it must be drained
+// concurrently with outcomes or the shared upstream pipeline will block.
+func drainActions(actions <-chan strategy.Action) {
+	go func() {
+		for range actions {
+		}
+	}()
+}
+
+func TestComputeWithOutcomeAndTimingAtClose(t *testing.T) {
+	s := &fixedActionsStrategy{actions: executionTimingActions()}
+
+	actions, outcomes := strategy.ComputeWithOutcomeAndTiming(s, executionTimingSnapshots(), strategy.AtClose)
+	drainActions(actions)
+
+	// Hand computed: buy at close 12 (shares = 1/12), hold at close 11, sell at close 14
+	// (balance = (1/12)*14), hold at close 13 (balance unchanged since fully in cash).
+	expected := helper.SliceToChan([]float64{0, -0.08, 0.17, 0.17})
+
+	actual := helper.RoundDigits(outcomes, 2)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestComputeWithOutcomeAndTimingNextOpen(t *testing.T) {
+	s := &fixedActionsStrategy{actions: executionTimingActions()}
+
+	actions, outcomes := strategy.ComputeWithOutcomeAndTiming(s, executionTimingSnapshots(), strategy.NextOpen)
+	drainActions(actions)
+
+	// Hand computed: the Buy signal on bar 1 executes at bar 2's open (13), the Sell signal on
+	// bar 3 executes at bar 4's open (15). The action on the last bar has no following bar and
+	// is dropped, so this channel is one element shorter than the actions channel.
+	//   buy at 13 (shares = 1/13) -> outcome 0
+	//   hold, valued at open 10   -> outcome (1/13)*10 - 1 = -0.230769...
+	//   sell at 15 (balance = (1/13)*15) -> outcome 0.153846...
+	expected := helper.SliceToChan([]float64{0, -0.23, 0.15})
+
+	actual := helper.RoundDigits(outcomes, 2)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestComputeWithOutcomeAndTimingNextClose(t *testing.T) {
+	s := &fixedActionsStrategy{actions: executionTimingActions()}
+
+	actions, outcomes := strategy.ComputeWithOutcomeAndTiming(s, executionTimingSnapshots(), strategy.NextClose)
+	drainActions(actions)
+
+	// Hand computed: the Buy signal on bar 1 executes at bar 2's close (11), the Sell signal on
+	// bar 3 executes at bar 4's close (13). As with NextOpen, the last bar's action is dropped
+	// since there is no following bar.
+	//   buy at 11 (shares = 1/11) -> outcome 0
+	//   hold, valued at close 14  -> outcome (1/11)*14 - 1 = 0.272727...
+	//   sell at 13 (balance = (1/11)*13) -> outcome 0.181818...
+	expected := helper.SliceToChan([]float64{0, 0.27, 0.18})
+
+	actual := helper.RoundDigits(outcomes, 2)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestComputeWithOutcomeAndTimingAtCloseMatchesDefault confirms that ExecutionTiming AtClose is
+// byte-for-byte identical to the existing default behavior of ComputeWithOutcome and
+// ComputeWithOutcomeWithContext, i.e. adding ExecutionTiming introduces zero behavior change to
+// the pre-existing default execution path.
+func TestComputeWithOutcomeAndTimingAtCloseMatchesDefault(t *testing.T) {
+	s := &fixedActionsStrategy{actions: executionTimingActions()}
+
+	defaultActions, defaultOutcomes := strategy.ComputeWithOutcome(s, executionTimingSnapshots())
+	drainActions(defaultActions)
+
+	timingActions, timingOutcomes := strategy.ComputeWithOutcomeAndTiming(s, executionTimingSnapshots(), strategy.AtClose)
+	drainActions(timingActions)
+
+	err := helper.CheckEquals(timingOutcomes, defaultOutcomes)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExecutionTimingString(t *testing.T) {
+	tests := []struct {
+		timing   strategy.ExecutionTiming
+		expected string
+	}{
+		{strategy.AtClose, "AtClose"},
+		{strategy.NextOpen, "NextOpen"},
+		{strategy.NextClose, "NextClose"},
+	}
+
+	for _, test := range tests {
+		actual := test.timing.String()
+		if actual != test.expected {
+			t.Fatalf("expected %s, got %s", test.expected, actual)
+		}
+	}
+}

--- a/strategy/outcome.go
+++ b/strategy/outcome.go
@@ -11,6 +11,15 @@ import (
 )
 
 // OutcomeWithContext simulates the potential result of executing the given actions based on the provided values, supporting context cancellation.
+//
+// The values and actions channels are paired positionally: the value at position i is assumed to be the
+// execution price for the action at position i. Callers that pass same-bar closing prices are therefore
+// simulating same-bar/"at close" execution, i.e. the trade is assumed to fill at the very same closing
+// price that produced the signal. This is unrealistic (a signal cannot be acted upon before the bar that
+// generated it has been observed) and tends to overstate backtest performance. Callers who want the more
+// realistic assumption of executing on the next bar's open or close should use
+// ComputeWithOutcomeAndTimingWithContext (or ComputeWithOutcomeAndTiming) with ExecutionTiming NextOpen
+// or NextClose instead of constructing the values channel directly.
 func OutcomeWithContext[T helper.Number](ctx context.Context, values <-chan T, actions <-chan Action) <-chan float64 {
 	balance := 1.0
 	shares := 0.0
@@ -29,6 +38,8 @@ func OutcomeWithContext[T helper.Number](ctx context.Context, values <-chan T, a
 }
 
 // Outcome simulates the potential result of executing the given actions based on the provided values.
+//
+// See OutcomeWithContext for details on the same-bar/"at close" execution assumption.
 //
 // Deprecated: Use OutcomeWithContext instead.
 func Outcome[T helper.Number](values <-chan T, actions <-chan Action) <-chan float64 {

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -75,6 +75,53 @@ func ComputeWithOutcome(s Strategy, c <-chan *asset.Snapshot) (<-chan Action, <-
 	return ComputeWithOutcomeWithContext(context.Background(), s, c)
 }
 
+// ComputeWithOutcomeAndTimingWithContext uses the given strategy to process the provided asset snapshots and
+// generates a stream of actionable recommendations and outcomes, using the given ExecutionTiming to decide
+// which price a simulated trade executes at, supporting context cancellation.
+//
+// With AtClose, this behaves identically to ComputeWithOutcomeWithContext: each action is paired with the
+// closing price of the same bar it was computed from.
+//
+// With NextOpen or NextClose, each action is instead paired with the opening or closing price of the
+// following bar. As a result, the returned outcomes channel yields one fewer value than the returned
+// actions channel, since there is no following bar for the last action. Callers that need the actions and
+// outcomes channels aligned position-for-position (for example, to build a report column) must account for
+// this offset themselves, the same way many strategies already skip-align channels of differing lengths.
+// Callers only interested in the final/aggregate outcome (for example, via helper.Last(outcomes, 1)) are
+// unaffected either way.
+func ComputeWithOutcomeAndTimingWithContext(ctx context.Context, s Strategy, c <-chan *asset.Snapshot, timing ExecutionTiming) (<-chan Action, <-chan float64) {
+	snapshots := helper.DuplicateWithContext(ctx, c, 2)
+
+	actions := helper.DuplicateWithContext(ctx, ComputeStrategyWithContext(ctx, s, snapshots[0]), 2)
+
+	var prices <-chan float64
+
+	switch timing {
+	case NextOpen:
+		prices = helper.SkipWithContext(ctx, asset.SnapshotsAsOpeningsWithContext(ctx, snapshots[1]), 1)
+
+	case NextClose:
+		prices = helper.SkipWithContext(ctx, asset.SnapshotsAsClosingsWithContext(ctx, snapshots[1]), 1)
+
+	default:
+		prices = asset.SnapshotsAsClosingsWithContext(ctx, snapshots[1])
+	}
+
+	outcomes := OutcomeWithContext(ctx, prices, actions[1])
+
+	return actions[0], outcomes
+}
+
+// ComputeWithOutcomeAndTiming uses the given strategy to process the provided asset snapshots and
+// generates a stream of actionable recommendations and outcomes, using the given ExecutionTiming to decide
+// which price a simulated trade executes at.
+//
+// See ComputeWithOutcomeAndTimingWithContext for details, including the note on the outcomes channel
+// being shorter than the actions channel when timing is NextOpen or NextClose.
+func ComputeWithOutcomeAndTiming(s Strategy, c <-chan *asset.Snapshot, timing ExecutionTiming) (<-chan Action, <-chan float64) {
+	return ComputeWithOutcomeAndTimingWithContext(context.Background(), s, c, timing)
+}
+
 // AllStrategies returns a slice containing references to all available base strategies.
 func AllStrategies() []Strategy {
 	return []Strategy{


### PR DESCRIPTION
## Summary

- `strategy.OutcomeWithContext` pairs each action with the price value from the *same* bar the action was computed from (same-bar/"at close" execution). This is unrealistic (a signal can't be acted on before the bar that generated it has been observed) and overstates backtest performance, especially for mean-reversion strategies. It isn't contradicting any doc comment today, so this is not a bug fix.
- This PR implements a design decision to add execution-timing as an **opt-in choice**, rather than changing the default behavior (which would force fixture regeneration across the ~50 example strategies).
- New `strategy.ExecutionTiming` enum: `AtClose` (current/default, unchanged), `NextOpen` (execute at next bar's open), `NextClose` (execute at next bar's close).
- New additive functions `strategy.ComputeWithOutcomeAndTimingWithContext` / `strategy.ComputeWithOutcomeAndTiming`, built on the existing `OutcomeWithContext` (unchanged) and `helper.SkipWithContext` to shift the price series by one bar for `NextOpen`/`NextClose`.
- Updated the doc comments on `Outcome`/`OutcomeWithContext` to explicitly state the same-bar/"at close" execution assumption and point callers wanting different semantics at the new functions.
- Existing `ComputeWithOutcomeWithContext`/`ComputeWithOutcome`/`OutcomeWithContext`/`Outcome` are **completely untouched behaviorally** — only doc comments changed on the latter two.
- Deliberately did **not** migrate any of the ~50 example strategies under `examples/` to the new timing option — that's a separate, future decision. Zero fixture regeneration was needed anywhere.

## Design notes

- For `NextOpen`/`NextClose`, the returned `outcomes` channel is one element shorter than the returned `actions` channel, since the price series has its first element skipped (there's no "next bar" for the last action). This is documented on the new functions.
- Verified by reading `helper.OperateWithContext` that this length mismatch is handled safely: when the shorter (skipped) price channel closes first, `OperateWithContext` calls `DrainWithContext` on the longer actions channel and returns cleanly — no goroutine leak or deadlock.
- Added a `String()` method on `ExecutionTiming` following common Go enum conventions.

## Test plan

- [x] Added `strategy/execution_timing_test.go` with a hand-computed synthetic 4-bar OHLC series and a fixed-action test strategy, independently verifying `AtClose`, `NextOpen`, and `NextClose` each produce distinct, correct outcomes.
- [x] Added a direct test confirming `ComputeWithOutcomeAndTiming` with `AtClose` produces byte-identical output to the existing `ComputeWithOutcome`/`ComputeWithOutcomeWithContext`, confirming zero behavior change to the default path.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no touched files reported (pre-existing formatting drift in unrelated files is unchanged)
- [x] `go test ./...` and `go test -race ./strategy/...` — all pass, nothing outside `strategy/execution_timing.go`/`execution_timing_test.go` and doc comments in `strategy/outcome.go`/`strategy/strategy.go` needed changes (no fixture regeneration under `examples/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp