### PR TITLE
Fix DaysBetween elapsed-hours division instead of calendar days

### DIFF
--- a/helper/days_between.go
+++ b/helper/days_between.go
@@ -5,11 +5,13 @@
 package helper
 
 import (
-	"math"
 	"time"
 )
 
 // DaysBetween calculates the days between the given two times.
 func DaysBetween(from, to time.Time) int {
-	return int(math.Floor(to.Sub(from).Hours() / 24))
+	fromDate := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+	toDate := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+
+	return int(toDate.Sub(fromDate) / (24 * time.Hour))
 }

--- a/helper/days_between_test.go
+++ b/helper/days_between_test.go
@@ -29,3 +29,34 @@ func TestDaysBetween(t *testing.T) {
 		t.Fatalf("actual %d expected %d", actual, expected)
 	}
 }
+
+func TestDaysBetweenAcrossDaylightSavingTransition(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Spring-forward transition on 2024-03-10 makes this span 71
+	// elapsed hours, not the 72 that 3 calendar days implies.
+	from := time.Date(2024, 3, 8, 0, 0, 0, 0, loc)
+	to := time.Date(2024, 3, 11, 0, 0, 0, 0, loc)
+
+	actual := helper.DaysBetween(from, to)
+	expected := 3
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+func TestDaysBetweenNonAlignedTimeOfDay(t *testing.T) {
+	from := time.Date(2024, 1, 1, 23, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 1, 2, 1, 0, 0, 0, time.UTC)
+
+	actual := helper.DaysBetween(from, to)
+	expected := 1
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- `helper.DaysBetween` divided elapsed duration by 24 hours, which miscounts across DST transitions and non-midnight-aligned timestamps
- Normalize both times to their calendar date in UTC (via `Year()/Month()/Day()`) before diffing, so the result is a true calendar-day count
- `DaysBetween` has zero in-tree callers (dead exported API), so this only changes behavior for external consumers

## Test plan
- [x] Added `TestDaysBetweenAcrossDaylightSavingTransition`: `America/New_York` 2024-03-08 -> 2024-03-11 (spans the spring-forward transition, 71 elapsed hours) now correctly returns 3; verified the old code returned 2
- [x] Added `TestDaysBetweenNonAlignedTimeOfDay`: 2024-01-01 23:00 UTC -> 2024-01-02 01:00 UTC now correctly returns 1; verified the old code returned 0
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` shows no touched files
- [x] `go test ./...`