### PR TITLE
Fix RoundDigit/Abs precision loss for large integer T

### DIFF
--- a/helper/abs.go
+++ b/helper/abs.go
@@ -11,12 +11,34 @@ import (
 
 // AbsWithContext calculates the absolute value of each value in a channel of type T.
 //
+// For an integer T, the absolute value is computed natively (negating
+// the value directly) rather than through a float64 round-trip, so
+// integers beyond float64's 53-bit exact-integer range (e.g., int64
+// values beyond 2^53) remain exact.
+//
+// This does not change the behavior at the minimum value of a signed
+// integer type (e.g., math.MinInt8, math.MinInt64), whose true
+// absolute value does not fit in that same type. Negating the minimum
+// value overflows and wraps back to the minimum value itself, which
+// matches the result previously produced by the float64 round-trip.
+// This is an inherent limitation of two's complement signed integers,
+// not something either implementation can silently correct.
+//
 // Example:
 //
 //	abs := helper.Abs(helper.SliceToChan([]int{-10, 20, -4, -5}))
 //	fmt.Println(helper.ChanToSlice(abs)) // [10, 20, 4, 5]
 func AbsWithContext[T Number](ctx context.Context, c <-chan T) <-chan T {
 	return ApplyWithContext(ctx, c, func(n T) T {
+		switch any(n).(type) {
+		case int, int8, int16, int32, int64:
+			if n < 0 {
+				return -n
+			}
+
+			return n
+		}
+
 		return T(math.Abs(float64(n)))
 	})
 }

--- a/helper/abs_test.go
+++ b/helper/abs_test.go
@@ -5,6 +5,7 @@
 package helper_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/cinar/indicator/v2/helper"
@@ -13,6 +14,38 @@ import (
 func TestAbs(t *testing.T) {
 	input := helper.SliceToChan([]int{-10, 20, -4, -5})
 	expected := helper.SliceToChan([]int{10, 20, 4, 5})
+
+	actual := helper.Abs(input)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAbsInt64PrecisionBeyondFloat64Range(t *testing.T) {
+	// Beyond float64's 53-bit exact-integer range (2^53). A lossy
+	// float64 round-trip would not return this exact value.
+	var n int64 = (1 << 62) + 1234567
+
+	input := helper.SliceToChan([]int64{-n})
+	expected := helper.SliceToChan([]int64{n})
+
+	actual := helper.Abs(input)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAbsMinInt8Overflow(t *testing.T) {
+	// The true absolute value of math.MinInt8 (128) does not fit in
+	// an int8 (range [-128, 127]). This documents the inherent,
+	// unfixable overflow behavior at the minimum value of a signed
+	// integer type: it wraps back to itself.
+	input := helper.SliceToChan([]int8{math.MinInt8})
+	expected := helper.SliceToChan([]int8{math.MinInt8})
 
 	actual := helper.Abs(input)
 

--- a/helper/round_digit.go
+++ b/helper/round_digit.go
@@ -8,11 +8,22 @@ import "math"
 
 // RoundDigit rounds the given float64 number to d decimal places.
 //
+// For an integer T, rounding to decimal places is a no-op, since an
+// integer has no fractional component to round away. In that case, n
+// is returned unchanged, which also avoids routing the value through
+// a lossy float64 round-trip for integers beyond float64's 53-bit
+// exact-integer range (e.g., int64 values beyond 2^53).
+//
 // Example:
 //
 //	n := helper.RoundDigit(10.1234, 2)
 //	fmt.Println(n) // 10.12
 func RoundDigit[T Number](n T, d int) T {
+	switch any(n).(type) {
+	case int, int8, int16, int32, int64:
+		return n
+	}
+
 	m := math.Pow(10, float64(d))
 	return T(math.Round(float64(n)*m) / m)
 }

--- a/helper/round_digit_test.go
+++ b/helper/round_digit_test.go
@@ -20,3 +20,16 @@ func TestRoundDigit(t *testing.T) {
 		t.Fatalf("actual %v expected %v", actual, expected)
 	}
 }
+
+func TestRoundDigitIntegerIsNoOp(t *testing.T) {
+	// Beyond float64's 53-bit exact-integer range (2^53). A lossy
+	// float64 round-trip would not return this exact value.
+	var input int64 = (1 << 62) + 1234567
+	expected := input
+
+	actual := helper.RoundDigit(input, 2)
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- `RoundDigit`/`RoundDigits`: rounding to N decimal places is a no-op for any integer `T` (no fractional part to round away). It previously routed integer `T` through a `float64` round-trip anyway (`T(math.Round(float64(n)*m) / m)`), which silently loses precision beyond `float64`'s 53-bit exact-integer range (e.g., `int64` values beyond `2^53`). Fixed by short-circuiting to return the integer input unchanged, detected via a `switch any(n).(type)` on the `Integer` member types (no reflection needed).
- `Abs`/`AbsWithContext`: previously computed `T(math.Abs(float64(n)))` for every `T`, same float64 round-trip precision loss for large `int64`. Fixed by computing the absolute value natively for integer `T` (`if n < 0 { return -n }`), which is exact for every integer value except the type's minimum value.
- **Documented, not "fixed" (mathematically unfixable)**: negating `math.MinInt8`/`math.MinInt64` still overflows and wraps back to the same negative value — the true absolute value (e.g. 128 for `MinInt8`) doesn't fit in the same signed integer type at all. This is an inherent limitation of two's-complement signed integers, not something a generic function can silently correct to a value that doesn't exist. Added a doc comment explaining this plus a test (`TestAbsMinInt8Overflow`) asserting the current, documented wrap-around behavior — this behavior is unchanged before/after the fix, since the old float64 path produced the identical wrapped result.

Both functions are dormant for integer `T` in the tree today — every in-tree caller (`trend/aroon.go`, `trend/tsi.go`, `trend/cci.go`, `trend/kama.go`) uses `float64`, so this is a zero-fixture-change, pure API-ergonomics/correctness fix for callers instantiating these generics with an integer type.

## Test plan
- [x] Added `TestRoundDigitIntegerIsNoOp` (`helper/round_digit_test.go`): `RoundDigit` on an `int64` beyond `2^53` returns the exact unchanged value.
- [x] Added `TestAbsInt64PrecisionBeyondFloat64Range` (`helper/abs_test.go`): `Abs` on a large `int64` (beyond `2^53`, not at `MinInt64`) returns the exact correct value.
- [x] Added `TestAbsMinInt8Overflow` (`helper/abs_test.go`): documents/confirms the pre-existing wrap-around behavior at `math.MinInt8`.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no touched files listed (pre-existing formatting drift in unrelated `examples/`/`strategy/`/`backtest/` files, untouched by this PR)
- [x] `go test ./...` — all packages pass, zero fixture changes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp