### PR TITLE
Document helper/window.go's aggregation function contract

### DIFF
--- a/helper/window.go
+++ b/helper/window.go
@@ -15,6 +15,28 @@ func Window[T any](c <-chan T, f func([]T, int) T, w int) <-chan T {
 
 // WindowWithContext returns a channel that emits the passed function result
 // within a sliding window of size w from the input channel c, supporting context cancellation.
+//
+// The aggregation function f receives (s, i), where s is the current window's
+// backing slice and i is the rotation offset of the oldest (chronologically
+// first) element in s. The backing slice is a fixed-size ring buffer that is
+// reused and rotated in place as new values arrive, so once the window has
+// filled up (len(s) == w), a plain left-to-right scan of s (e.g. range s, or
+// s[0], s[1], ...) does NOT visit the values in chronological order — it
+// visits them in whatever order they currently sit in the ring.
+//
+// A custom f that cares about temporal order must use i, not raw position:
+//   - Oldest-to-newest: the k-th oldest element (0-based) is s[(i+k)%len(s)].
+//     Equivalently, s rotated left by i is the chronological sequence.
+//   - Newest-to-oldest: use the SlicesReverse(s, i, ...) helper, which starts
+//     just before i (the newest element) and walks backward, wrapping around,
+//     stopping at i (the oldest element). See max_since.go and min_since.go
+//     for a worked example.
+//   - While the window is still filling (len(s) < w), i is always 0 and s has
+//     not wrapped yet, so it is already in chronological order as-is.
+//
+// Order-independent aggregations (e.g. min/max of the set, as in highest.go
+// and lowest.go) can safely ignore i, since any permutation of the same
+// values yields the same result.
 func WindowWithContext[T any](ctx context.Context, c <-chan T, f func([]T, int) T, w int) <-chan T {
 	r := make(chan T)
 
@@ -40,8 +62,14 @@ func WindowWithContext[T any](ctx context.Context, c <-chan T, f func([]T, int) 
 				var out T
 				if cnt < w {
 					cnt++
+					// Window not yet full: h[:cnt] has not wrapped, so it is
+					// already in chronological order and the offset is 0.
 					out = f(h[:cnt], 0)
 				} else {
+					// Window full: h is a rotated ring buffer. (n+1)%w is the
+					// index of the oldest element; f must use it (rather than
+					// scanning h by raw position) to recover chronological
+					// order. See the WindowWithContext doc comment above.
 					out = f(h, (n+1)%w)
 				}
 				select {


### PR DESCRIPTION
## Summary
- `helper/window.go`'s `WindowWithContext` passes each custom aggregation function `f` a rotation-offset index alongside its backing slice, because that slice is a fixed-size ring buffer reused across calls. Iterating the slice by raw position (`range s`, `s[0]`, ...) instead of using the offset silently returns values in rotated order rather than chronological order once the window fills up.
- This contract was previously undocumented; every in-tree caller (`highest.go`, `Lowest.go`, `max_since.go`, `min_since.go`) already gets it right, but a new external caller writing a custom order-sensitive aggregation function had no way to know the pitfall.
- Adds a doc comment on `WindowWithContext` explaining the rotation-offset index precisely (oldest-to-newest via `s[(i+k)%len(s)]`, newest-to-oldest via the existing `SlicesReverse(s, i, ...)` helper), plus short inline comments at both call sites of `f`, pointing to `max_since.go`/`min_since.go` as worked examples.
- Documentation only — no logic, behavior, or test fixture changes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no touched files listed; pre-existing unrelated formatting diffs elsewhere untouched)
- [x] `go test ./...` (all packages pass)
- [x] `git diff` confirms only comments changed in `helper/window.go`

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp