### PR TITLE
Fix doc-comment and code-example drift

### DIFF
--- a/helper/change_percent.go
+++ b/helper/change_percent.go
@@ -13,8 +13,8 @@ import (
 //
 // Example:
 //
-//	c := helper.ChanToSlice([]float64{1, 2, 5, 5, 8, 2, 1, 1, 3, 4})
-//	actual := helper.ChangePercent(c, 2))
+//	c := helper.SliceToChan([]float64{1, 2, 5, 5, 8, 2, 1, 1, 3, 4})
+//	actual := helper.ChangePercent(c, 2)
 //	fmt.Println(helper.ChanToSlice(actual)) // [400, 150, 60, -60, -87.5, -50, 200, 300]
 func ChangePercentWithContext[T Number](ctx context.Context, c <-chan T, before int) <-chan T {
 	return MultiplyByWithContext(ctx, ChangeRatioWithContext(ctx, c, before), 100)

--- a/helper/change_ratio.go
+++ b/helper/change_ratio.go
@@ -13,9 +13,9 @@ import (
 //
 // Example:
 //
-//	c := helper.ChanToSlice([]float64{1, 2, 5, 5, 8, 2, 1, 1, 3, 4})
-//	actual := helper.ChangeRatio(c, 2))
-//	fmt.Println(helper.ChanToSlice(actual)) // [400, 150, 60, -60, -87.5, -50, 200, 300]
+//	c := helper.SliceToChan([]float64{1, 2, 5, 5, 8, 2, 1, 1, 3, 4})
+//	actual := helper.ChangeRatio(c, 2)
+//	fmt.Println(helper.ChanToSlice(actual)) // [4, 1.5, 0.6, -0.6, -0.875, -0.5, 2, 3]
 func ChangeRatioWithContext[T Number](ctx context.Context, c <-chan T, before int) <-chan T {
 	cs := DuplicateWithContext(ctx, c, 2)
 	cs[1] = BufferedWithContext(ctx, cs[1], before)

--- a/helper/keep_negatives.go
+++ b/helper/keep_negatives.go
@@ -14,7 +14,7 @@ import (
 // Example:
 //
 //	c := helper.SliceToChan([]int{-10, 20, 4, -5})
-//	negatives := helper.KeepPositives(c)
+//	negatives := helper.KeepNegatives(c)
 //	fmt.Println(helper.ChanToSlice(negatives)) // [-10, 0, 0, -5]
 func KeepNegativesWithContext[T Number](ctx context.Context, c <-chan T) <-chan T {
 	return ApplyWithContext(ctx, c, func(n T) T {

--- a/momentum/awesome_oscillator.go
+++ b/momentum/awesome_oscillator.go
@@ -30,7 +30,7 @@ const (
 //
 // Example:
 //
-//	ao := momentum.AwesomeOscillator[float64]()
+//	ao := momentum.NewAwesomeOscillator[float64]()
 //	values := ao.Compute(lows, highs)
 type AwesomeOscillator[T helper.Number] struct {
 	// ShortSma is the SMA for the short period.

--- a/momentum/ichimoku_cloud.go
+++ b/momentum/ichimoku_cloud.go
@@ -42,7 +42,7 @@ const (
 //
 // Example:
 //
-//	ic := momentum.IchimokuCloud[float64]()
+//	ic := momentum.NewIchimokuCloud[float64]()
 //	conversionLine, baseLine, leadingSpanA, leasingSpanB, laggingSpan := ic.Compute(highs, lows, closings)
 type IchimokuCloud[T helper.Number] struct {
 	// ConversionMax is the conversion Moving Max instance.

--- a/momentum/ppo.go
+++ b/momentum/ppo.go
@@ -32,7 +32,7 @@ const (
 //
 // Example:
 //
-//	ppo := momentum.Ppo[float64]()
+//	ppo := momentum.NewPpo[float64]()
 //	p, s, h := ppo.Compute(closings)
 type Ppo[T helper.Float] struct {
 	// ShortEma is the short EMA instance.

--- a/momentum/pvo.go
+++ b/momentum/pvo.go
@@ -32,7 +32,7 @@ const (
 //
 // Example:
 //
-//	pvo := momentum.Pvo[float64]()
+//	pvo := momentum.NewPvo[float64]()
 //	p, s, h := pvo.Compute(volumes)
 type Pvo[T helper.Float] struct {
 	// ShortEma is the short EMA instance.

--- a/momentum/qstick.go
+++ b/momentum/qstick.go
@@ -28,7 +28,7 @@ const (
 //
 // Example:
 //
-//	qstick := momentum.Qstick[float64]()
+//	qstick := momentum.NewQstick[float64]()
 //	qstick.Sma.Period = 50
 //
 //	values := qstick.Compute(openings, closings)

--- a/momentum/stochastic_oscillator.go
+++ b/momentum/stochastic_oscillator.go
@@ -28,8 +28,8 @@ const (
 //
 // Example:
 //
-//	so := momentum.StochasticOscillator[float64]()
-//	k, d := wr.Compute(highs, lows, closings)
+//	so := momentum.NewStochasticOscillator[float64]()
+//	k, d := so.Compute(highs, lows, closings)
 type StochasticOscillator[T helper.Number] struct {
 	// Max is the Moving Max instance.
 	Max *trend.MovingMax[T]

--- a/momentum/williams_r.go
+++ b/momentum/williams_r.go
@@ -26,7 +26,7 @@ const (
 //
 // Example:
 //
-//	wr := momentum.WilliamsR[float64]()
+//	wr := momentum.NewWilliamsR[float64]()
 //	values := wr.Compute(highs, lows, closings)
 type WilliamsR[T helper.Float] struct {
 	// Max is the Moving Max instance.

--- a/trend/kama.go
+++ b/trend/kama.go
@@ -86,7 +86,7 @@ func (k *Kama[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-c
 	//	Efficiency Ratio (ER) = Direction / Volatility
 	ers := helper.Divide(directions, volatilitys)
 
-	//	Smoothing Constant (SC) = (ER * (2/(Slow + 1) - 2/(Fast + 1)) + (2/(Slow + 1)))^2
+	//	Smoothing Constant (SC) = (ER * (2/(Fast + 1) - 2/(Slow + 1)) + (2/(Slow + 1)))^2
 	fastSc := T(2.0) / T(k.FastScPeriod+1)
 	slowSc := T(2.0) / T(k.SlowScPeriod+1)
 

--- a/trend/mass_index.go
+++ b/trend/mass_index.go
@@ -37,7 +37,7 @@ type MassIndex[T helper.Float] struct {
 	MovingSum *MovingSum[T]
 }
 
-// NewMassIndex function initializes a new APO instance
+// NewMassIndex function initializes a new Mass Index instance
 // with the default parameters.
 func NewMassIndex[T helper.Float]() *MassIndex[T] {
 	mi := &MassIndex[T]{

--- a/trend/mls.go
+++ b/trend/mls.go
@@ -15,7 +15,7 @@ import (
 //
 //	y = mx + b
 //	b = y-intercept
-//	y = slope
+//	m = slope
 //
 //	m = (period * sumXY - sumX * sumY) / (period * sumX2 - sumX * sumX)
 //	b = (sumY - m * sumX) / period

--- a/volatility/atr.go
+++ b/volatility/atr.go
@@ -60,7 +60,7 @@ func (a *Atr[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <
 	return atr
 }
 
-// IdlePeriod is the initial period that Acceleration Bands won't yield any results.
+// IdlePeriod is the initial period that ATR won't yield any results.
 func (a *Atr[T]) IdlePeriod() int {
 	// Ma idle period and for using the previous closing.
 	return a.Ma.IdlePeriod() + 1

--- a/volatility/chandelier_exit.go
+++ b/volatility/chandelier_exit.go
@@ -20,10 +20,10 @@ const (
 )
 
 // ChandelierExit represents the configuration parameters for calculating the Chandelier Exit.
-// It sets a trailing stop-loss based on the Average True Value (ATR).
+// It sets a trailing stop-loss based on the Average True Range (ATR).
 //
-//	Chandelier Exit Long = 22-Period SMA High - ATR(22) * 3
-//	Chandelier Exit Short = 22-Period SMA Low + ATR(22) * 3
+//	Chandelier Exit Long = 22-Period Highest High - ATR(22) * 3
+//	Chandelier Exit Short = 22-Period Lowest Low + ATR(22) * 3
 //
 // Example:
 //

--- a/volatility/keltner_channel.go
+++ b/volatility/keltner_channel.go
@@ -26,8 +26,8 @@ const (
 //
 // Example:
 //
-//	dc := volatility.NewKeltnerChannel[float64]()
-//	result := dc.Compute(highs, lows, closings)
+//	kc := volatility.NewKeltnerChannel[float64]()
+//	result := kc.Compute(highs, lows, closings)
 type KeltnerChannel[T helper.Float] struct {
 	// Atr is the ATR instance.
 	Atr *Atr[T]

--- a/volume/cmf.go
+++ b/volume/cmf.go
@@ -62,7 +62,7 @@ func (c *Cmf[T]) ComputeWithContext(ctx context.Context, highs, lows, closings, 
 	)
 }
 
-// IdlePeriod is the initial period that MFV won't yield any results.
+// IdlePeriod is the initial period that CMF won't yield any results.
 func (c *Cmf[T]) IdlePeriod() int {
 	return c.Sum.IdlePeriod()
 }

--- a/volume/nvi.go
+++ b/volume/nvi.go
@@ -18,7 +18,7 @@ const (
 // Nvi holds configuration parameters for calculating the Negative Volume Index (NVI). It is a cumulative
 // indicator using the change in volume to decide when the smart money is active.
 //
-// If Volume is greather than Previous Volume:
+// If Volume is greater than Previous Volume:
 //
 //	NVI = Previous NVI
 //
@@ -52,7 +52,7 @@ func (n *Nvi[T]) ComputeWithContext(ctx context.Context, closings, volumes <-cha
 	previous := n.Initial
 
 	return helper.OperateWithContext(ctx, closingRatios, volumeChanges, func(closingRatio, volumeChange T) T {
-		// If Volume is greather than Previous Volume:
+		// If Volume is greater than Previous Volume:
 		//	NVI = Previous NVI
 		current := previous
 


### PR DESCRIPTION
## Summary

Comment-only cleanup sweep fixing confirmed doc-comment and `Example:` code-block typos/errors. No behavior, signatures, or fixtures changed — verified via `git diff` that only comment lines were touched.

- [x] `trend/cci.go` — already fixed by a prior PR (`NewCci()` is correctly referenced); no change needed.
- [x] `trend/mls.go` — doc comment `y = slope` corrected to `m = slope` (matches the formula's actual variable name).
- [x] `trend/mass_index.go` — `NewMassIndex` doc comment copy-paste error ("APO instance") corrected to "Mass Index instance".
- [x] `helper/change_percent.go` — `Example:` used `ChanToSlice` on a slice literal (wrong direction) and had a stray extra `)`; fixed to `SliceToChan` and balanced parens.
- [x] `helper/change_ratio.go` — same `ChanToSlice`/stray-paren issue as above, plus the example's shown output was copy-pasted from `ChangePercent`'s percentage-scaled numbers (`[400, 150, ...]`); corrected to the raw ratio values `ChangeRatio` actually returns (`[4, 1.5, 0.6, -0.6, -0.875, -0.5, 2, 3]`).
- [x] `helper/keep_negatives.go` — example called `KeepPositives` while describing `KeepNegatives`; fixed the function name reference.
- [x] `trend/kama.go` — inline comment had `Fast`/`Slow` reversed in the Smoothing Constant formula, contradicting both the code (`fastSc-slowSc`) and the struct-level doc comment; corrected to match.
- [x] `volatility/atr.go` — `IdlePeriod` doc comment referenced "Acceleration Bands" instead of ATR; fixed.
- [x] `volatility/chandelier_exit.go` — doc comment said "SMA High"/"SMA Low" though the code uses Highest High/Lowest Low (`MovingMax`/`MovingMin`); fixed doc to match implementation. Also corrected "Average True Value (ATR)" to "Average True Range (ATR)" (ATR's actual expansion), found during the same read.
- [x] `volatility/keltner_channel.go` — example used Donchian-Channel-style variable names (`dc`) for a Keltner Channel example; renamed to `kc` for both the constructor and `.Compute` call.
- [x] `volume/cmf.go` — `Cmf.IdlePeriod` doc comment said "MFV" where it should say "CMF".
- [x] `volume/nvi.go` — "greather" typo fixed to "greater" in both the struct-level doc comment and the matching inline comment.

### Broader `Example:`-block sweep (trend/momentum/volatility/volume)

Grepped every `// Example:` doc block in `trend/`, `momentum/`, `volatility/`, and `volume/` for wrong or missing `New`-prefixed constructor calls. `trend/`, `volatility/`, and `volume/` were already clean. Found and fixed 7 additional missing-`New`-prefix examples in `momentum/`, none of which were in the original explicit list:

- [x] `momentum/awesome_oscillator.go` — `momentum.AwesomeOscillator[float64]()` → `momentum.NewAwesomeOscillator[float64]()`
- [x] `momentum/ichimoku_cloud.go` — `momentum.IchimokuCloud[float64]()` → `momentum.NewIchimokuCloud[float64]()`
- [x] `momentum/williams_r.go` — `momentum.WilliamsR[float64]()` → `momentum.NewWilliamsR[float64]()`
- [x] `momentum/ppo.go` — `momentum.Ppo[float64]()` → `momentum.NewPpo[float64]()`
- [x] `momentum/pvo.go` — `momentum.Pvo[float64]()` → `momentum.NewPvo[float64]()`
- [x] `momentum/qstick.go` — `momentum.Qstick[float64]()` → `momentum.NewQstick[float64]()`
- [x] `momentum/stochastic_oscillator.go` — `momentum.StochasticOscillator[float64]()` → `momentum.NewStochasticOscillator[float64]()`, and also fixed the example's second line which called `.Compute` on an undeclared `wr` variable instead of the declared `so`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -l .` shows no touched files (pre-existing unrelated formatting diffs in `examples/`, `backtest/`, `strategy/` untouched by this change)
- [x] `go test ./...` passes, all packages green, zero fixture changes
- [x] `git diff` reviewed — confirmed only comment lines changed, no code logic, struct fields, or signatures touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp