### PR TITLE
Fix ctx propagation in Kama/Cci/ActionSources; add SinceWithContext

### DIFF
--- a/helper/since.go
+++ b/helper/since.go
@@ -4,15 +4,17 @@
 
 package helper
 
-// Since counts the number of periods since the last change of
-// value in a channel of numbers.
-func Since[T comparable, R Number](c <-chan T) <-chan R {
+import "context"
+
+// SinceWithContext counts the number of periods since the last change of
+// value in a channel of numbers, supporting context cancellation.
+func SinceWithContext[T comparable, R Number](ctx context.Context, c <-chan T) <-chan R {
 	first := true
 
 	var last T
 	var count R
 
-	return Map(c, func(n T) R {
+	return MapWithContext(ctx, c, func(n T) R {
 		if first || last != n {
 			first = false
 			last = n
@@ -23,4 +25,11 @@ func Since[T comparable, R Number](c <-chan T) <-chan R {
 
 		return count
 	})
+}
+
+// Since wraps SinceWithContext for backwards compatibility.
+//
+// Deprecated: Use SinceWithContext instead.
+func Since[T comparable, R Number](c <-chan T) <-chan R {
+	return SinceWithContext[T, R](context.Background(), c)
 }

--- a/helper/since_test.go
+++ b/helper/since_test.go
@@ -5,7 +5,9 @@
 package helper_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -19,5 +21,32 @@ func TestSince(t *testing.T) {
 	err := helper.CheckEquals(actual, expected)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSinceWithContext(t *testing.T) {
+	input := helper.SliceToChan([]int{1, 1, 2, 2, 2, 1, 2, 3, 3, 4})
+	expected := helper.SliceToChan([]int{0, 1, 0, 1, 2, 0, 0, 0, 1, 0})
+
+	actual := helper.SinceWithContext[int, int](context.Background(), input)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSinceWithContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	input := make(chan int)
+
+	since := helper.SinceWithContext[int, int](ctx, input)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := <-since; ok {
+		t.Fatal("Since channel should be closed after cancellation")
 	}
 }

--- a/strategy/and_strategy.go
+++ b/strategy/and_strategy.go
@@ -41,7 +41,7 @@ func (a *AndStrategy) Name() string {
 func (a *AndStrategy) ComputeWithContext(ctx context.Context, snapshots <-chan *asset.Snapshot) <-chan Action {
 	result := make(chan Action)
 
-	sources := ActionSources(a.Strategies, snapshots)
+	sources := ActionSourcesWithContext(ctx, a.Strategies, snapshots)
 
 	go func() {
 		defer close(result)

--- a/strategy/and_strategy_test.go
+++ b/strategy/and_strategy_test.go
@@ -5,6 +5,8 @@
 package strategy_test
 
 import (
+	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -70,6 +72,33 @@ func TestAndStrategyNoStrategies(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout - result channel never closed")
+	}
+}
+
+func TestAndStrategyCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	snapshots := make(chan *asset.Snapshot)
+
+	and := strategy.NewAndStrategy("And Strategy")
+	and.Strategies = append(and.Strategies, strategy.NewBuyAndHoldStrategy(), strategy.NewBuyAndHoldStrategy())
+
+	actual := and.ComputeWithContext(ctx, snapshots)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	if _, ok := <-actual; ok {
+		t.Fatal("And strategy channel should be closed after cancellation")
 	}
 }
 

--- a/strategy/majority_strategy.go
+++ b/strategy/majority_strategy.go
@@ -42,7 +42,7 @@ func (a *MajorityStrategy) Name() string {
 func (a *MajorityStrategy) ComputeWithContext(ctx context.Context, snapshots <-chan *asset.Snapshot) <-chan Action {
 	result := make(chan Action)
 
-	sources := ActionSources(a.Strategies, snapshots)
+	sources := ActionSourcesWithContext(ctx, a.Strategies, snapshots)
 
 	go func() {
 		defer close(result)

--- a/strategy/majority_strategy_test.go
+++ b/strategy/majority_strategy_test.go
@@ -5,6 +5,8 @@
 package strategy_test
 
 import (
+	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -51,6 +53,33 @@ func TestMajorityStrategyNoStrategies(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout - result channel never closed")
+	}
+}
+
+func TestMajorityStrategyCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	snapshots := make(chan *asset.Snapshot)
+
+	majority := strategy.NewMajorityStrategy("Majority Strategy")
+	majority.Strategies = append(majority.Strategies, strategy.NewBuyAndHoldStrategy(), strategy.NewBuyAndHoldStrategy())
+
+	actual := majority.ComputeWithContext(ctx, snapshots)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	if _, ok := <-actual; ok {
+		t.Fatal("Majority strategy channel should be closed after cancellation")
 	}
 }
 

--- a/strategy/or_strategy.go
+++ b/strategy/or_strategy.go
@@ -38,7 +38,7 @@ func (a *OrStrategy) Name() string {
 func (a *OrStrategy) ComputeWithContext(ctx context.Context, snapshots <-chan *asset.Snapshot) <-chan Action {
 	result := make(chan Action)
 
-	sources := ActionSources(a.Strategies, snapshots)
+	sources := ActionSourcesWithContext(ctx, a.Strategies, snapshots)
 
 	go func() {
 		defer close(result)

--- a/strategy/or_strategy_test.go
+++ b/strategy/or_strategy_test.go
@@ -5,6 +5,8 @@
 package strategy_test
 
 import (
+	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -51,6 +53,33 @@ func TestOrStrategyNoStrategies(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout - result channel never closed")
+	}
+}
+
+func TestOrStrategyCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	snapshots := make(chan *asset.Snapshot)
+
+	or := strategy.NewOrStrategy("Or Strategy")
+	or.Strategies = append(or.Strategies, strategy.NewBuyAndHoldStrategy(), strategy.NewBuyAndHoldStrategy())
+
+	actual := or.ComputeWithContext(ctx, snapshots)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	if _, ok := <-actual; ok {
+		t.Fatal("Or strategy channel should be closed after cancellation")
 	}
 }
 

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -82,17 +82,26 @@ func AllStrategies() []Strategy {
 	}
 }
 
-// ActionSources creates a slice of action channels, one for each strategy, where each channel emits actions
-// computed by its corresponding strategy based on snapshots from the provided snapshot channel.
-func ActionSources(strategies []Strategy, snapshots <-chan *asset.Snapshot) []<-chan Action {
-	snapshotsSplice := helper.Duplicate(snapshots, len(strategies))
+// ActionSourcesWithContext creates a slice of action channels, one for each strategy, where each channel emits
+// actions computed by its corresponding strategy based on snapshots from the provided snapshot channel,
+// supporting context cancellation.
+func ActionSourcesWithContext(ctx context.Context, strategies []Strategy, snapshots <-chan *asset.Snapshot) []<-chan Action {
+	snapshotsSplice := helper.DuplicateWithContext(ctx, snapshots, len(strategies))
 	sources := make([]<-chan Action, len(strategies))
 
 	for i, strategy := range strategies {
 		sources[i] = DenormalizeActions(
-			strategy.Compute(snapshotsSplice[i]),
+			ComputeStrategyWithContext(ctx, strategy, snapshotsSplice[i]),
 		)
 	}
 
 	return sources
+}
+
+// ActionSources creates a slice of action channels, one for each strategy, where each channel emits actions
+// computed by its corresponding strategy based on snapshots from the provided snapshot channel.
+//
+// Deprecated: Use ActionSourcesWithContext instead.
+func ActionSources(strategies []Strategy, snapshots <-chan *asset.Snapshot) []<-chan Action {
+	return ActionSourcesWithContext(context.Background(), strategies, snapshots)
 }

--- a/strategy/strategy_test.go
+++ b/strategy/strategy_test.go
@@ -6,6 +6,7 @@ package strategy_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -54,5 +55,68 @@ func TestComputeStrategyWithContextFallback(t *testing.T) {
 
 	if count != 2 {
 		t.Fatalf("expected 2 actions, got %d", count)
+	}
+}
+
+func TestActionSourcesWithContext(t *testing.T) {
+	date1, _ := time.Parse("2006-01-02", "2021-01-01")
+	date2, _ := time.Parse("2006-01-02", "2021-01-02")
+
+	snapshots := helper.SliceToChan([]*asset.Snapshot{
+		{Date: date1, Close: 100},
+		{Date: date2, Close: 101},
+	})
+
+	strategies := []strategy.Strategy{
+		strategy.NewBuyAndHoldStrategy(),
+		strategy.NewBuyAndHoldStrategy(),
+	}
+
+	sources := strategy.ActionSourcesWithContext(context.Background(), strategies, snapshots)
+
+	if len(sources) != len(strategies) {
+		t.Fatalf("expected %d sources, got %d", len(strategies), len(sources))
+	}
+
+	for _, source := range sources {
+		count := 0
+		for range source {
+			count++
+		}
+
+		if count != 2 {
+			t.Fatalf("expected 2 actions, got %d", count)
+		}
+	}
+}
+
+func TestActionSourcesWithContextCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	snapshots := make(chan *asset.Snapshot)
+
+	strategies := []strategy.Strategy{
+		strategy.NewBuyAndHoldStrategy(),
+		strategy.NewBuyAndHoldStrategy(),
+	}
+
+	sources := strategy.ActionSourcesWithContext(ctx, strategies, snapshots)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	for _, source := range sources {
+		if _, ok := <-source; ok {
+			t.Fatal("Source channel should be closed after cancellation")
+		}
 	}
 }

--- a/trend/cci.go
+++ b/trend/cci.go
@@ -51,12 +51,12 @@ func (c *Cci[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <
 	sma1 := NewSmaWithPeriod[T](c.Period)
 	sma2 := NewSmaWithPeriod[T](c.Period)
 
-	tps := helper.Duplicate[T](
+	tps := helper.DuplicateWithContext[T](ctx,
 		typicalPrice.ComputeWithContext(ctx, highs, lows, closings),
 		3,
 	)
 
-	mas := helper.Duplicate[T](
+	mas := helper.DuplicateWithContext[T](ctx,
 		sma1.ComputeWithContext(ctx, tps[0]),
 		2,
 	)

--- a/trend/cci_test.go
+++ b/trend/cci_test.go
@@ -5,7 +5,10 @@
 package trend_test
 
 import (
+	"context"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -40,5 +43,32 @@ func TestCci(t *testing.T) {
 	err = helper.CheckEquals(actual, expected)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCciCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	highs := make(chan float64)
+	lows := make(chan float64)
+	closings := make(chan float64)
+
+	cci := trend.NewCci[float64]()
+	actual := cci.ComputeWithContext(ctx, highs, lows, closings)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	if _, ok := <-actual; ok {
+		t.Fatal("Cci channel should be closed after cancellation")
 	}
 }

--- a/trend/kama.go
+++ b/trend/kama.go
@@ -71,15 +71,15 @@ func (k *Kama[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-c
 	closingsSplice := helper.DuplicateWithContext(ctx, closings, 3)
 
 	//	Direction = Abs(Close - Previous Close Period Ago)
-	directions := helper.Abs(
-		helper.Change(closingsSplice[0], k.ErPeriod),
+	directions := helper.AbsWithContext(ctx,
+		helper.ChangeWithContext(ctx, closingsSplice[0], k.ErPeriod),
 	)
 
 	//	Volatility = MovingSum(Period, Abs(Close - Previous Close))
 	movingSum := NewMovingSumWithPeriod[T](k.ErPeriod)
 	volatilitys := movingSum.ComputeWithContext(ctx,
-		helper.Abs(
-			helper.Change(closingsSplice[1], 1),
+		helper.AbsWithContext(ctx,
+			helper.ChangeWithContext(ctx, closingsSplice[1], 1),
 		),
 	)
 

--- a/trend/kama_test.go
+++ b/trend/kama_test.go
@@ -5,7 +5,10 @@
 package trend_test
 
 import (
+	"context"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -48,6 +51,31 @@ func TestKamaEmpty(t *testing.T) {
 	err := helper.CheckEquals(actual, expected)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestKamaCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	closings := make(chan float64)
+
+	kama := trend.NewKama[float64]()
+	actual := kama.ComputeWithContext(ctx, closings)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+
+	if _, ok := <-actual; ok {
+		t.Fatal("Kama channel should be closed after cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `trend/kama.go` and `trend/cci.go`'s `ComputeWithContext` internally called plain `helper.Abs`/`helper.Change`/`helper.Duplicate` instead of their `WithContext` variants, so cancellation of the outer `ctx` never reached those sub-goroutines (they ran under `context.Background()`). Switched both to use `AbsWithContext`, `ChangeWithContext`, and `DuplicateWithContext`.
- `strategy.ActionSources` had no `ctx` parameter and called plain `helper.Duplicate`/`strategy.Compute`, so `AndStrategy`, `OrStrategy`, and `MajorityStrategy`'s `ComputeWithContext` could never cancel their per-strategy sub-computations. Added `ActionSourcesWithContext(ctx, strategies, snapshots)` (using `DuplicateWithContext` and the existing `ComputeStrategyWithContext` helper), kept `ActionSources` as a deprecated thin wrapper, and updated all three composite strategies to call `ActionSourcesWithContext(ctx, ...)`.
- `helper/since.go` had no `WithContext` variant, unlike nearly every other helper. Added `SinceWithContext`, implemented via `MapWithContext` the same way `Since` was implemented via `Map`, and made `Since` a deprecated thin wrapper.

This is internal plumbing only — no behavior change for existing (non-context) callers; all existing fixtures/tests pass unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no touched files reported (pre-existing unrelated formatting gaps in `examples/` etc. untouched)
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./trend/... ./strategy/... ./helper/...` — pass
- [x] Added cancellation-propagation tests (`TestKamaCancellation`, `TestCciCancellation`, `TestActionSourcesWithContextCancellation`, `TestAndStrategyCancellation`, `TestOrStrategyCancellation`, `TestMajorityStrategyCancellation`, `TestSinceWithContextCancellation`) modeled on the existing `TestAroonCancellation`/`TestCancellationLeaks` pattern
- [x] Added correctness tests (`TestActionSourcesWithContext`, `TestSinceWithContext`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp