### PR TITLE
Add missing String() methods across four indicator packages

### DIFF
--- a/momentum/awesome_oscillator.go
+++ b/momentum/awesome_oscillator.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -69,6 +70,11 @@ func (a *AwesomeOscillator[T]) ComputeWithContext(ctx context.Context, highs, lo
 // IdlePeriod is the initial period that Awesome Oscillator won't yield any results.
 func (a *AwesomeOscillator[T]) IdlePeriod() int {
 	return a.LongSma.IdlePeriod()
+}
+
+// String is the string representation of the Awesome Oscillator.
+func (a *AwesomeOscillator[T]) String() string {
+	return fmt.Sprintf("AO(%d,%d)", a.ShortSma.Period, a.LongSma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/awesome_oscillator_test.go
+++ b/momentum/awesome_oscillator_test.go
@@ -39,3 +39,12 @@ func TestAwesomeOscillator(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAwesomeOscillatorString(t *testing.T) {
+	expected := "AO(5,34)"
+	actual := momentum.NewAwesomeOscillator[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/chaikin_oscillator.go
+++ b/momentum/chaikin_oscillator.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -71,6 +72,11 @@ func (c *ChaikinOscillator[T]) ComputeWithContext(ctx context.Context, highs, lo
 // IdlePeriod is the initial period that Chaikin Oscillator won't yield any results.
 func (c *ChaikinOscillator[T]) IdlePeriod() int {
 	return c.LongEma.IdlePeriod()
+}
+
+// String is the string representation of the Chaikin Oscillator.
+func (c *ChaikinOscillator[T]) String() string {
+	return fmt.Sprintf("CO(%d,%d)", c.ShortEma.Period, c.LongEma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/chaikin_oscillator_test.go
+++ b/momentum/chaikin_oscillator_test.go
@@ -47,3 +47,12 @@ func TestChaikinOscillator(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestChaikinOscillatorString(t *testing.T) {
+	expected := "CO(3,10)"
+	actual := momentum.NewChaikinOscillator[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/connors_rsi.go
+++ b/momentum/connors_rsi.go
@@ -206,6 +206,11 @@ func (s *Streak[T]) IdlePeriod() int {
 	return 1
 }
 
+// String is the string representation of the Streak.
+func (s *Streak[T]) String() string {
+	return "STREAK"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/momentum/connors_rsi_test.go
+++ b/momentum/connors_rsi_test.go
@@ -47,3 +47,12 @@ func TestConnorsRsiString(t *testing.T) {
 		t.Fatalf("expected %v, got %v", expected, actual)
 	}
 }
+
+func TestStreakString(t *testing.T) {
+	expected := "STREAK"
+	actual := momentum.NewStreak[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+}

--- a/momentum/ichimoku_cloud.go
+++ b/momentum/ichimoku_cloud.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -158,6 +159,11 @@ func (i *IchimokuCloud[T]) ComputeWithContext(ctx context.Context, highs, lows, 
 // IdlePeriod is the initial period that Ichimoku Cloud won't yield any results.
 func (i *IchimokuCloud[T]) IdlePeriod() int {
 	return i.LeadingMax.IdlePeriod() + i.LaggingPeriod
+}
+
+// String is the string representation of the Ichimoku Cloud.
+func (i *IchimokuCloud[T]) String() string {
+	return fmt.Sprintf("ICHIMOKU(%d,%d,%d,%d)", i.ConversionMax.Period, i.BaseMax.Period, i.LeadingMax.Period, i.LaggingPeriod)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/ichimoku_cloud_test.go
+++ b/momentum/ichimoku_cloud_test.go
@@ -66,3 +66,12 @@ func TestIchimokuCloud(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIchimokuCloudString(t *testing.T) {
+	expected := "ICHIMOKU(9,26,52,26)"
+	actual := momentum.NewIchimokuCloud[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/ppo.go
+++ b/momentum/ppo.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -95,6 +96,11 @@ func (p *Ppo[T]) ComputeWithContext(ctx context.Context, closings <-chan T) (<-c
 // IdlePeriod is the initial period that Percentage Price Oscillator won't yield any results.
 func (p *Ppo[T]) IdlePeriod() int {
 	return p.LongEma.IdlePeriod() + p.SignalEma.IdlePeriod()
+}
+
+// String is the string representation of the PPO.
+func (p *Ppo[T]) String() string {
+	return fmt.Sprintf("PPO(%d,%d,%d)", p.ShortEma.Period, p.LongEma.Period, p.SignalEma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/ppo_test.go
+++ b/momentum/ppo_test.go
@@ -45,3 +45,12 @@ func TestPpo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPpoString(t *testing.T) {
+	expected := "PPO(12,26,9)"
+	actual := momentum.NewPpo[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/prings_special_k.go
+++ b/momentum/prings_special_k.go
@@ -144,6 +144,11 @@ func (p *PringsSpecialK[T]) IdlePeriod() int {
 	return p.Sma195Roc530.IdlePeriod() + p.Roc530.IdlePeriod()
 }
 
+// String is the string representation of the Pring's Special K.
+func (p *PringsSpecialK[T]) String() string {
+	return "SPECIALK"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/momentum/prings_special_k_test.go
+++ b/momentum/prings_special_k_test.go
@@ -111,3 +111,12 @@ func TestPringsSpecialKComputeConstantInput(t *testing.T) {
 		}
 	}
 }
+
+func TestPringsSpecialKString(t *testing.T) {
+	expected := "SPECIALK"
+	actual := NewPringsSpecialK[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/pvo.go
+++ b/momentum/pvo.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -95,6 +96,11 @@ func (p *Pvo[T]) ComputeWithContext(ctx context.Context, volumes <-chan T) (<-ch
 // IdlePeriod is the initial period that Percentage Volume Oscillator won't yield any results.
 func (p *Pvo[T]) IdlePeriod() int {
 	return p.LongEma.IdlePeriod() + p.SignalEma.IdlePeriod()
+}
+
+// String is the string representation of the PVO.
+func (p *Pvo[T]) String() string {
+	return fmt.Sprintf("PVO(%d,%d,%d)", p.ShortEma.Period, p.LongEma.Period, p.SignalEma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/pvo_test.go
+++ b/momentum/pvo_test.go
@@ -45,3 +45,12 @@ func TestPvo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPvoString(t *testing.T) {
+	expected := "PVO(12,26,9)"
+	actual := momentum.NewPvo[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/qstick.go
+++ b/momentum/qstick.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -58,6 +59,11 @@ func (q *Qstick[T]) ComputeWithContext(ctx context.Context, openings, closings <
 // IdlePeriod is the initial period that Qstick won't yield any results.
 func (q *Qstick[T]) IdlePeriod() int {
 	return q.Sma.IdlePeriod()
+}
+
+// String is the string representation of the Qstick.
+func (q *Qstick[T]) String() string {
+	return fmt.Sprintf("QSTICK(%d)", q.Sma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/qstick_test.go
+++ b/momentum/qstick_test.go
@@ -39,3 +39,12 @@ func TestQstick(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestQstickString(t *testing.T) {
+	expected := "QSTICK(20)"
+	actual := momentum.NewQstick[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/rsi.go
+++ b/momentum/rsi.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -74,6 +75,11 @@ func (r *Rsi[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-ch
 // IdlePeriod is the initial period that Relative Strength Index won't yield any results.
 func (r *Rsi[T]) IdlePeriod() int {
 	return r.Rma.IdlePeriod() + 1
+}
+
+// String is the string representation of the RSI.
+func (r *Rsi[T]) String() string {
+	return fmt.Sprintf("RSI(%d)", r.Rma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/rsi_test.go
+++ b/momentum/rsi_test.go
@@ -57,3 +57,12 @@ func TestRsiFlatMarket(t *testing.T) {
 		}
 	}
 }
+
+func TestRsiString(t *testing.T) {
+	expected := "RSI(14)"
+	actual := momentum.NewRsi[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/stochastic_oscillator.go
+++ b/momentum/stochastic_oscillator.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -79,6 +80,11 @@ func (s *StochasticOscillator[T]) ComputeWithContext(ctx context.Context, highs,
 // IdlePeriod is the initial period that Stochastic Oscillator won't yield any results.
 func (s *StochasticOscillator[T]) IdlePeriod() int {
 	return s.Max.IdlePeriod() + s.Sma.IdlePeriod()
+}
+
+// String is the string representation of the Stochastic Oscillator.
+func (s *StochasticOscillator[T]) String() string {
+	return fmt.Sprintf("STOCHOSC(%d,%d)", s.Max.Period, s.Sma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/stochastic_oscillator_test.go
+++ b/momentum/stochastic_oscillator_test.go
@@ -45,3 +45,12 @@ func TestStochasticOscillator(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestStochasticOscillatorString(t *testing.T) {
+	expected := "STOCHOSC(14,3)"
+	actual := momentum.NewStochasticOscillator[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/stochastic_rsi.go
+++ b/momentum/stochastic_rsi.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -81,6 +82,11 @@ func (s *StochasticRsi[T]) ComputeWithContext(ctx context.Context, closings <-ch
 // IdlePeriod is the initial period that Stochasic RSI won't yield any results.
 func (s *StochasticRsi[T]) IdlePeriod() int {
 	return s.Rsi.IdlePeriod() + s.Min.IdlePeriod()
+}
+
+// String is the string representation of the Stochastic RSI.
+func (s *StochasticRsi[T]) String() string {
+	return fmt.Sprintf("STOCHRSI(%d)", s.Min.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/stochastic_rsi_test.go
+++ b/momentum/stochastic_rsi_test.go
@@ -37,3 +37,12 @@ func TestStochasticRsi(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestStochasticRsiString(t *testing.T) {
+	expected := "STOCHRSI(14)"
+	actual := momentum.NewStochasticRsi[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/td_sequential.go
+++ b/momentum/td_sequential.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -267,4 +268,9 @@ func (t *TdSequential[T]) Compute(closings <-chan T) (<-chan T, <-chan T, <-chan
 // IdlePeriod is the initial period that TD Sequential won't yield meaningful results.
 func (t *TdSequential[T]) IdlePeriod() int {
 	return t.Lookback + t.SetupPeriod + t.CountdownPeriod
+}
+
+// String is the string representation of the TD Sequential.
+func (t *TdSequential[T]) String() string {
+	return fmt.Sprintf("TDSEQUENTIAL(%d,%d,%d,%d)", t.Lookback, t.CountdownLookback, t.SetupPeriod, t.CountdownPeriod)
 }

--- a/momentum/td_sequential_test.go
+++ b/momentum/td_sequential_test.go
@@ -156,3 +156,12 @@ func TestTdSequentialCountdownCrossCancel(t *testing.T) {
 		t.Fatalf("row 25: buyCountdown = %v, want 0 (stays cancelled, not 5)", rows[25].buyCountdown)
 	}
 }
+
+func TestTdSequentialString(t *testing.T) {
+	expected := "TDSEQUENTIAL(4,2,9,13)"
+	actual := momentum.NewTdSequential[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/williams_r.go
+++ b/momentum/williams_r.go
@@ -6,6 +6,7 @@ package momentum
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -64,6 +65,11 @@ func (w *WilliamsR[T]) ComputeWithContext(ctx context.Context, highs, lows, clos
 // IdlePeriod is the initial period that Williams R won't yield any results.
 func (w *WilliamsR[T]) IdlePeriod() int {
 	return w.Max.IdlePeriod()
+}
+
+// String is the string representation of the Williams R.
+func (w *WilliamsR[T]) String() string {
+	return fmt.Sprintf("WILLIAMSR(%d)", w.Max.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/momentum/williams_r_test.go
+++ b/momentum/williams_r_test.go
@@ -41,3 +41,12 @@ func TestWilliamsR(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWilliamsRString(t *testing.T) {
+	expected := "WILLIAMSR(14)"
+	actual := momentum.NewWilliamsR[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/apo.go
+++ b/trend/apo.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	//goland:noinspection ALL
@@ -91,6 +92,11 @@ func (apo *Apo[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T 
 // IdlePeriod is the initial period that APO won't yield any results.
 func (apo *Apo[T]) IdlePeriod() int {
 	return apo.SlowPeriod - 1
+}
+
+// String is the string representation of the APO.
+func (apo *Apo[T]) String() string {
+	return fmt.Sprintf("APO(%d,%d)", apo.FastPeriod, apo.SlowPeriod)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/apo_test.go
+++ b/trend/apo_test.go
@@ -76,3 +76,12 @@ func TestApoWithCustomSmoothing(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestApoString(t *testing.T) {
+	expected := "APO(14,30)"
+	actual := trend.NewApo[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/aroon.go
+++ b/trend/aroon.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -73,6 +74,11 @@ func (a *Aroon[T]) ComputeWithContext(ctx context.Context, high, low <-chan T) (
 // IdlePeriod is the initial period that Aroon won't yield any results.
 func (a *Aroon[T]) IdlePeriod() int {
 	return a.Period - 1
+}
+
+// String is the string representation of the Aroon.
+func (a *Aroon[T]) String() string {
+	return fmt.Sprintf("AROON(%d)", a.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/aroon_test.go
+++ b/trend/aroon_test.go
@@ -167,3 +167,12 @@ func TestAroonValidateDefinition(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAroonString(t *testing.T) {
+	expected := "AROON(25)"
+	actual := trend.NewAroon[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/bop.go
+++ b/trend/bop.go
@@ -36,6 +36,11 @@ func (*Bop[T]) IdlePeriod() int {
 	return 0
 }
 
+// String is the string representation of the BOP.
+func (*Bop[T]) String() string {
+	return "BOP"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/trend/bop_test.go
+++ b/trend/bop_test.go
@@ -42,3 +42,12 @@ func TestBop(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestBopString(t *testing.T) {
+	expected := "BOP"
+	actual := trend.NewBop[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/cci.go
+++ b/trend/cci.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -84,6 +85,11 @@ func (c *Cci[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <
 // IdlePeriod is the initial period that CCI won't yield any results.
 func (c *Cci[T]) IdlePeriod() int {
 	return (c.Period * 2) - 2
+}
+
+// String is the string representation of the CCI.
+func (c *Cci[T]) String() string {
+	return fmt.Sprintf("CCI(%d)", c.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/cci_test.go
+++ b/trend/cci_test.go
@@ -72,3 +72,12 @@ func TestCciCancellation(t *testing.T) {
 		t.Fatal("Cci channel should be closed after cancellation")
 	}
 }
+
+func TestCciString(t *testing.T) {
+	expected := "CCI(20)"
+	actual := trend.NewCci[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/cfo.go
+++ b/trend/cfo.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -64,6 +65,11 @@ func (c *Cfo[T]) ComputeWithContext(ctx context.Context, closing <-chan T) <-cha
 // IdlePeriod is the initial period that CFO won't yield any results.
 func (c *Cfo[T]) IdlePeriod() int {
 	return c.Mlr.IdlePeriod()
+}
+
+// String is the string representation of the CFO.
+func (c *Cfo[T]) String() string {
+	return fmt.Sprintf("CFO(%d)", c.Mlr.Mls.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/cfo_test.go
+++ b/trend/cfo_test.go
@@ -35,3 +35,12 @@ func TestCfo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCfoString(t *testing.T) {
+	expected := "CFO(14)"
+	actual := trend.NewCfo[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/dema.go
+++ b/trend/dema.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -57,6 +58,11 @@ func (d *Dema[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 // IdlePeriod is the initial period that DEMA won't yield any results.
 func (d *Dema[T]) IdlePeriod() int {
 	return d.Ema1.Period + d.Ema2.Period - 2
+}
+
+// String is the string representation of the DEMA.
+func (d *Dema[T]) String() string {
+	return fmt.Sprintf("DEMA(%d,%d)", d.Ema1.Period, d.Ema2.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/dema_test.go
+++ b/trend/dema_test.go
@@ -37,3 +37,12 @@ func TestDema(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDemaString(t *testing.T) {
+	expected := "DEMA(20,20)"
+	actual := trend.NewDema[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/kdj.go
+++ b/trend/kdj.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -110,6 +111,11 @@ func (kdj *Kdj[T]) ComputeWithContext(ctx context.Context, high, low, closing <-
 // IdlePeriod is the initial period that KDJ won't yield any results.
 func (kdj *Kdj[T]) IdlePeriod() int {
 	return kdj.MovingMax.Period + kdj.Sma1.Period + kdj.Sma2.Period - 3
+}
+
+// String is the string representation of the KDJ.
+func (kdj *Kdj[T]) String() string {
+	return fmt.Sprintf("KDJ(%d,%d,%d)", kdj.MovingMax.Period, kdj.Sma1.Period, kdj.Sma2.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/kdj_test.go
+++ b/trend/kdj_test.go
@@ -51,3 +51,12 @@ func TestKdj(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestKdjString(t *testing.T) {
+	expected := "KDJ(9,3,3)"
+	actual := trend.NewKdj[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/macd.go
+++ b/trend/macd.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -75,6 +76,11 @@ func (m *Macd[T]) ComputeWithContext(ctx context.Context, c <-chan T) (<-chan T,
 // IdlePeriod is the initial period that MACD won't yield any results.
 func (m *Macd[T]) IdlePeriod() int {
 	return m.Ema2.Period + m.Ema3.Period - 2
+}
+
+// String is the string representation of the MACD.
+func (m *Macd[T]) String() string {
+	return fmt.Sprintf("MACD(%d,%d,%d)", m.Ema1.Period, m.Ema2.Period, m.Ema3.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/macd_test.go
+++ b/trend/macd_test.go
@@ -47,3 +47,12 @@ func TestMacd(t *testing.T) {
 		}
 	}
 }
+
+func TestMacdString(t *testing.T) {
+	expected := "MACD(12,26,9)"
+	actual := trend.NewMacd[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/mass_index.go
+++ b/trend/mass_index.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -71,6 +72,11 @@ func (m *MassIndex[T]) ComputeWithContext(ctx context.Context, highs, lows <-cha
 // IdlePeriod is the initial period that Mass Index won't yield any results.
 func (m *MassIndex[T]) IdlePeriod() int {
 	return m.Ema1.Period + m.Ema2.Period + m.MovingSum.Period - 3
+}
+
+// String is the string representation of the Mass Index.
+func (m *MassIndex[T]) String() string {
+	return fmt.Sprintf("MASSINDEX(%d,%d,%d)", m.Ema1.Period, m.Ema2.Period, m.MovingSum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/mass_index_test.go
+++ b/trend/mass_index_test.go
@@ -39,3 +39,12 @@ func TestMassIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMassIndexString(t *testing.T) {
+	expected := "MASSINDEX(9,9,25)"
+	actual := trend.NewMassIndex[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/mlr.go
+++ b/trend/mlr.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -60,6 +61,11 @@ func (m *Mlr[T]) ComputeWithContext(ctx context.Context, x, y <-chan T) <-chan T
 // IdlePeriod is the initial period that MLR won't yield any results.
 func (m *Mlr[T]) IdlePeriod() int {
 	return m.Mls.IdlePeriod()
+}
+
+// String is the string representation of the MLR.
+func (m *Mlr[T]) String() string {
+	return fmt.Sprintf("MLR(%d)", m.Mls.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/mlr_test.go
+++ b/trend/mlr_test.go
@@ -54,3 +54,12 @@ func TestMlr(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMlrString(t *testing.T) {
+	expected := "MLR(4)"
+	actual := trend.NewMlrWithPeriod[float64](4).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/mls.go
+++ b/trend/mls.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -100,6 +101,11 @@ func (m *Mls[T]) ComputeWithContext(ctx context.Context, x, y <-chan T) (<-chan 
 // IdlePeriod is the initial period that MLS won't yield any results.
 func (m *Mls[T]) IdlePeriod() int {
 	return m.Sum.IdlePeriod()
+}
+
+// String is the string representation of the MLS.
+func (m *Mls[T]) String() string {
+	return fmt.Sprintf("MLS(%d)", m.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/mls_test.go
+++ b/trend/mls_test.go
@@ -58,3 +58,12 @@ func TestMls(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMlsString(t *testing.T) {
+	expected := "MLS(5)"
+	actual := trend.NewMlsWithPeriod[float64](5).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/moving_max.go
+++ b/trend/moving_max.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -51,6 +52,11 @@ func (m *MovingMax[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-cha
 // IdlePeriod is the initial period that Mocing Max won't yield any results.
 func (m *MovingMax[T]) IdlePeriod() int {
 	return m.Period - 1
+}
+
+// String is the string representation of the Moving Max.
+func (m *MovingMax[T]) String() string {
+	return fmt.Sprintf("MOVINGMAX(%d)", m.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/moving_max_test.go
+++ b/trend/moving_max_test.go
@@ -23,3 +23,12 @@ func TestMovingMax(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMovingMaxString(t *testing.T) {
+	expected := "MOVINGMAX(4)"
+	actual := trend.NewMovingMaxWithPeriod[int](4).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/moving_min.go
+++ b/trend/moving_min.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -51,6 +52,11 @@ func (m *MovingMin[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-cha
 // IdlePeriod is the initial period that Mocing Min won't yield any results.
 func (m *MovingMin[T]) IdlePeriod() int {
 	return m.Period - 1
+}
+
+// String is the string representation of the Moving Min.
+func (m *MovingMin[T]) String() string {
+	return fmt.Sprintf("MOVINGMIN(%d)", m.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/moving_min_test.go
+++ b/trend/moving_min_test.go
@@ -23,3 +23,12 @@ func TestMovingMin(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMovingMinString(t *testing.T) {
+	expected := "MOVINGMIN(4)"
+	actual := trend.NewMovingMinWithPeriod[int](4).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/moving_sum.go
+++ b/trend/moving_sum.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/cinar/indicator/v2/helper"
@@ -129,6 +130,11 @@ func isNaNOrInf[T helper.Number](v T) bool {
 // IdlePeriod is the initial period that Moving Sum won't yield any results.
 func (m *MovingSum[T]) IdlePeriod() int {
 	return m.Period - 1
+}
+
+// String is the string representation of the Moving Sum.
+func (m *MovingSum[T]) String() string {
+	return fmt.Sprintf("MOVINGSUM(%d)", m.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/moving_sum_test.go
+++ b/trend/moving_sum_test.go
@@ -206,3 +206,12 @@ func TestMovingSumFloatDriftNearZeroSum(t *testing.T) {
 		t.Fatalf("MovingSum (%v) is not more accurate than the naive running sum (%v) in the near-zero-sum regime", actualMaxErr, naiveMaxErr)
 	}
 }
+
+func TestMovingSumString(t *testing.T) {
+	expected := "MOVINGSUM(4)"
+	actual := trend.NewMovingSumWithPeriod[int](4).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/rma.go
+++ b/trend/rma.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -102,4 +103,9 @@ func (r *Rma[T]) Compute(c <-chan T) <-chan T {
 // IdlePeriod is the initial period that RMA won't yield any results.
 func (r *Rma[T]) IdlePeriod() int {
 	return r.Period - 1
+}
+
+// String is the string representation of the RMA.
+func (r *Rma[T]) String() string {
+	return fmt.Sprintf("RMA(%d)", r.Period)
 }

--- a/trend/rma_test.go
+++ b/trend/rma_test.go
@@ -39,3 +39,12 @@ func TestRma(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRmaString(t *testing.T) {
+	expected := "RMA(15)"
+	actual := trend.NewRmaWithPeriod[float64](15).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/slow_stochastic.go
+++ b/trend/slow_stochastic.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -101,6 +102,11 @@ func (s *SlowStochastic[T]) ComputeWithContext(ctx context.Context, values <-cha
 // IdlePeriod is the initial period that Slow Stochastic won't yield any results.
 func (s *SlowStochastic[T]) IdlePeriod() int {
 	return s.Period + s.KPeriod + s.DPeriod - 3
+}
+
+// String is the string representation of the Slow Stochastic.
+func (s *SlowStochastic[T]) String() string {
+	return fmt.Sprintf("SLOWSTOCH(%d,%d,%d)", s.Period, s.KPeriod, s.DPeriod)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/slow_stochastic_test.go
+++ b/trend/slow_stochastic_test.go
@@ -54,3 +54,12 @@ func TestNewSlowStochasticWithPeriod(t *testing.T) {
 		t.Fatalf("expected period 14, got %d", s.Period)
 	}
 }
+
+func TestSlowStochasticString(t *testing.T) {
+	expected := "SLOWSTOCH(14,3,3)"
+	actual := trend.NewSlowStochasticWithPeriod[float64](14, 3, 3).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/stc.go
+++ b/trend/stc.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -119,6 +120,11 @@ func (s *Stc[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 // IdlePeriod is the initial period that STC won't yield any results.
 func (s *Stc[T]) IdlePeriod() int {
 	return s.Apo.IdlePeriod() + 2*s.Stochastic.IdlePeriod()
+}
+
+// String is the string representation of the STC.
+func (s *Stc[T]) String() string {
+	return fmt.Sprintf("STC(%d,%d,%d,%d)", s.FastPeriod, s.SlowPeriod, s.KPeriod, s.DPeriod)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/stc_test.go
+++ b/trend/stc_test.go
@@ -102,3 +102,12 @@ func TestStcDeadlock(t *testing.T) {
 		t.Fatal("Stc.ComputeWithContext deadlocked")
 	}
 }
+
+func TestStcString(t *testing.T) {
+	expected := "STC(23,50,10,3)"
+	actual := trend.NewStc[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/stochastic.go
+++ b/trend/stochastic.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -86,6 +87,11 @@ func (s *Stochastic[T]) ComputeWithContext(ctx context.Context, values <-chan T)
 // IdlePeriod is the initial period that Stochastic won't yield any results.
 func (s *Stochastic[T]) IdlePeriod() int {
 	return s.Period + s.Sma.Period - 2
+}
+
+// String is the string representation of the Stochastic.
+func (s *Stochastic[T]) String() string {
+	return fmt.Sprintf("STOCHASTIC(%d,%d)", s.Period, s.Sma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/stochastic_test.go
+++ b/trend/stochastic_test.go
@@ -41,3 +41,12 @@ func TestStochastic(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestStochasticString(t *testing.T) {
+	expected := "STOCHASTIC(10,3)"
+	actual := trend.NewStochastic[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/tema.go
+++ b/trend/tema.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -62,6 +63,11 @@ func (t *Tema[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 // IdlePeriod is the initial period that TEMA won't yield any results.
 func (t *Tema[T]) IdlePeriod() int {
 	return t.Ema1.Period + t.Ema2.Period + t.Ema3.Period - 3
+}
+
+// String is the string representation of the TEMA.
+func (t *Tema[T]) String() string {
+	return fmt.Sprintf("TEMA(%d,%d,%d)", t.Ema1.Period, t.Ema2.Period, t.Ema3.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/tema_test.go
+++ b/trend/tema_test.go
@@ -38,3 +38,12 @@ func TestTema(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTemaString(t *testing.T) {
+	expected := "TEMA(20,20,20)"
+	actual := trend.NewTema[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/trima.go
+++ b/trend/trima.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -64,6 +65,11 @@ func (t *Trima[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T 
 func (t *Trima[T]) IdlePeriod() int {
 	period1, period2 := t.calculatePeriods()
 	return period1 + period2 - 2
+}
+
+// String is the string representation of the TRIMA.
+func (t *Trima[T]) String() string {
+	return fmt.Sprintf("TRIMA(%d)", t.Period)
 }
 
 // calculatePeriods calculates the individual periods to use based on the

--- a/trend/trima_test.go
+++ b/trend/trima_test.go
@@ -82,3 +82,12 @@ func TestTrimaWithEvenPeriod(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTrimaString(t *testing.T) {
+	expected := "TRIMA(15)"
+	actual := trend.NewTrima[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/trix.go
+++ b/trend/trix.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -56,6 +57,11 @@ func (t *Trix[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 // IdlePeriod is the initial period that TRIX won't yield any results.
 func (t *Trix[T]) IdlePeriod() int {
 	return (t.Period * 3) - 3 + 1
+}
+
+// String is the string representation of the TRIX.
+func (t *Trix[T]) String() string {
+	return fmt.Sprintf("TRIX(%d)", t.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/trix_test.go
+++ b/trend/trix_test.go
@@ -38,3 +38,12 @@ func TestTrix(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTrixString(t *testing.T) {
+	expected := "TRIX(15)"
+	actual := trend.NewTrix[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/typical_price.go
+++ b/trend/typical_price.go
@@ -36,6 +36,11 @@ func (*TypicalPrice[T]) IdlePeriod() int {
 	return 0
 }
 
+// String is the string representation of the Typical Price.
+func (*TypicalPrice[T]) String() string {
+	return "Typical Price"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/trend/typical_price_test.go
+++ b/trend/typical_price_test.go
@@ -40,3 +40,12 @@ func TestTypicalPrice(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTypicalPriceString(t *testing.T) {
+	expected := "Typical Price"
+	actual := trend.NewTypicalPrice[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/trend/vwma.go
+++ b/trend/vwma.go
@@ -6,6 +6,7 @@ package trend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -47,6 +48,11 @@ func (v *Vwma[T]) ComputeWithContext(ctx context.Context, closing, volume <-chan
 // IdlePeriod is the initial period that VWMA won't yield any results.
 func (v *Vwma[T]) IdlePeriod() int {
 	return v.Period - 1
+}
+
+// String is the string representation of the VWMA.
+func (v *Vwma[T]) String() string {
+	return fmt.Sprintf("VWMA(%d)", v.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/trend/vwma_test.go
+++ b/trend/vwma_test.go
@@ -40,3 +40,12 @@ func TestVwma(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestVwmaString(t *testing.T) {
+	expected := "VWMA(20)"
+	actual := trend.NewVwma[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/acceleration_bands.go
+++ b/volatility/acceleration_bands.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -78,6 +79,11 @@ func (a *AccelerationBands[T]) ComputeWithContext(ctx context.Context, high, low
 // IdlePeriod is the initial period that Acceleration Bands won't yield any results.
 func (a *AccelerationBands[T]) IdlePeriod() int {
 	return a.Period - 1
+}
+
+// String is the string representation of the Acceleration Bands.
+func (a *AccelerationBands[T]) String() string {
+	return fmt.Sprintf("ACCELBANDS(%d)", a.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/acceleration_bands_test.go
+++ b/volatility/acceleration_bands_test.go
@@ -49,3 +49,12 @@ func TestAccelerationBands(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAccelerationBandsString(t *testing.T) {
+	expected := "ACCELBANDS(20)"
+	actual := volatility.NewAccelerationBands[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/atr.go
+++ b/volatility/atr.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -64,6 +65,11 @@ func (a *Atr[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <
 func (a *Atr[T]) IdlePeriod() int {
 	// Ma idle period and for using the previous closing.
 	return a.Ma.IdlePeriod() + 1
+}
+
+// String is the string representation of the ATR.
+func (a *Atr[T]) String() string {
+	return fmt.Sprintf("ATR(%s)", a.Ma.String())
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/atr_test.go
+++ b/volatility/atr_test.go
@@ -41,3 +41,12 @@ func TestAtr(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAtrString(t *testing.T) {
+	expected := "ATR(SMA(14))"
+	actual := volatility.NewAtr[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/bollinger_band_width.go
+++ b/volatility/bollinger_band_width.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -47,6 +48,11 @@ func (b *BollingerBandWidth[T]) ComputeWithContext(ctx context.Context, c <-chan
 // IdlePeriod is the initial period that Bollinger Band Width won't yield any results.
 func (b *BollingerBandWidth[T]) IdlePeriod() int {
 	return b.BollingerBands.IdlePeriod()
+}
+
+// String is the string representation of the Bollinger Band Width.
+func (b *BollingerBandWidth[T]) String() string {
+	return fmt.Sprintf("BBW(%d)", b.BollingerBands.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/bollinger_band_width_test.go
+++ b/volatility/bollinger_band_width_test.go
@@ -37,3 +37,12 @@ func TestBollingerBandWidth(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestBollingerBandWidthString(t *testing.T) {
+	expected := "BBW(20)"
+	actual := volatility.NewBollingerBandWidth[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/bollinger_bands.go
+++ b/volatility/bollinger_bands.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -82,6 +83,11 @@ func (b *BollingerBands[T]) ComputeWithContext(ctx context.Context, c <-chan T) 
 // IdlePeriod is the initial period that Bollinger Bands won't yield any results.
 func (b *BollingerBands[T]) IdlePeriod() int {
 	return b.Period - 1
+}
+
+// String is the string representation of the Bollinger Bands.
+func (b *BollingerBands[T]) String() string {
+	return fmt.Sprintf("BBANDS(%d,%v)", b.Period, b.Multiplier)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/bollinger_bands_test.go
+++ b/volatility/bollinger_bands_test.go
@@ -45,3 +45,12 @@ func TestBollingerBands(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestBollingerBandsString(t *testing.T) {
+	expected := "BBANDS(20,2)"
+	actual := volatility.NewBollingerBands[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/chandelier_exit.go
+++ b/volatility/chandelier_exit.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -78,6 +79,11 @@ func (c *ChandelierExit[T]) ComputeWithContext(ctx context.Context, highs, lows,
 // IdlePeriod is the initial period that Chandelier Exit won't yield any results.
 func (c *ChandelierExit[T]) IdlePeriod() int {
 	return c.Period
+}
+
+// String is the string representation of the Chandelier Exit.
+func (c *ChandelierExit[T]) String() string {
+	return fmt.Sprintf("CE(%d,%v)", c.Period, c.Multiplier)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/chandelier_exit_test.go
+++ b/volatility/chandelier_exit_test.go
@@ -45,3 +45,12 @@ func TestChandelierExit(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestChandelierExitString(t *testing.T) {
+	expected := "CE(22,3)"
+	actual := volatility.NewChandelierExit[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/donchian_channel.go
+++ b/volatility/donchian_channel.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -71,6 +72,11 @@ func (d *DonchianChannel[T]) ComputeWithContext(ctx context.Context, highs, lows
 // IdlePeriod is the initial period that Donchian Channel won't yield any results.
 func (d *DonchianChannel[T]) IdlePeriod() int {
 	return d.Max.IdlePeriod()
+}
+
+// String is the string representation of the Donchian Channel.
+func (d *DonchianChannel[T]) String() string {
+	return fmt.Sprintf("DC(%d)", d.Max.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/donchian_channel_test.go
+++ b/volatility/donchian_channel_test.go
@@ -47,3 +47,12 @@ func TestDonchianChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDonchianChannelString(t *testing.T) {
+	expected := "DC(20)"
+	actual := volatility.NewDonchianChannel[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/keltner_channel.go
+++ b/volatility/keltner_channel.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -79,6 +80,11 @@ func (k *KeltnerChannel[T]) ComputeWithContext(ctx context.Context, highs, lows,
 // IdlePeriod is the initial period that Keltner Channel won't yield any results.
 func (k *KeltnerChannel[T]) IdlePeriod() int {
 	return k.Atr.IdlePeriod()
+}
+
+// String is the string representation of the Keltner Channel.
+func (k *KeltnerChannel[T]) String() string {
+	return fmt.Sprintf("KC(%d)", k.Ema.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/keltner_channel_test.go
+++ b/volatility/keltner_channel_test.go
@@ -49,3 +49,12 @@ func TestKeltnerChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestKeltnerChannelString(t *testing.T) {
+	expected := "KC(20)"
+	actual := volatility.NewKeltnerChannel[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/moving_std.go
+++ b/volatility/moving_std.go
@@ -5,6 +5,7 @@
 package volatility
 
 import (
+	"fmt"
 	"math"
 
 	"context"
@@ -96,4 +97,9 @@ func (m *MovingStd[T]) Compute(c <-chan T) <-chan T {
 // IdlePeriod is the initial period that Moving Standard Deviation won't yield any results.
 func (m *MovingStd[T]) IdlePeriod() int {
 	return m.Period - 1
+}
+
+// String is the string representation of the Moving Standard Deviation.
+func (m *MovingStd[T]) String() string {
+	return fmt.Sprintf("MOVINGSTD(%d)", m.Period)
 }

--- a/volatility/moving_std_test.go
+++ b/volatility/moving_std_test.go
@@ -37,3 +37,12 @@ func TestMovingStd(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMovingStdString(t *testing.T) {
+	expected := "MOVINGSTD(20)"
+	actual := volatility.NewMovingStdWithPeriod[float64](20).String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/po.go
+++ b/volatility/po.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -105,6 +106,11 @@ func (p *Po[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-
 // IdlePeriod is the initial period that PO won't yield any results.
 func (p *Po[T]) IdlePeriod() int {
 	return p.mls.IdlePeriod() + p.min.IdlePeriod()
+}
+
+// String is the string representation of the PO.
+func (p *Po[T]) String() string {
+	return fmt.Sprintf("PO(%d)", p.mls.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/po_test.go
+++ b/volatility/po_test.go
@@ -41,3 +41,12 @@ func TestPo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPoString(t *testing.T) {
+	expected := "PO(14)"
+	actual := volatility.NewPo[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/super_trend.go
+++ b/volatility/super_trend.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -160,6 +161,11 @@ func (s *SuperTrend[T]) ComputeWithContext(ctx context.Context, highs, lows, clo
 // IdlePeriod is the initial period that Super Trend won't yield any results.
 func (s *SuperTrend[T]) IdlePeriod() int {
 	return s.Atr.IdlePeriod()
+}
+
+// String is the string representation of the Super Trend.
+func (s *SuperTrend[T]) String() string {
+	return fmt.Sprintf("SUPERTREND(%s,%v)", s.Atr.Ma.String(), s.Multiplier)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/super_trend_test.go
+++ b/volatility/super_trend_test.go
@@ -41,3 +41,12 @@ func TestSuperTrend(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestSuperTrendString(t *testing.T) {
+	expected := "SUPERTREND(HMA(14),2.5)"
+	actual := volatility.NewSuperTrend[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volatility/ulcer_index.go
+++ b/volatility/ulcer_index.go
@@ -6,6 +6,7 @@ package volatility
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -75,6 +76,11 @@ func (u *UlcerIndex[T]) ComputeWithContext(ctx context.Context, closings <-chan 
 // IdlePeriod is the initial period that Ulcer Index won't yield any results.
 func (u *UlcerIndex[T]) IdlePeriod() int {
 	return (u.Period - 1) * 2
+}
+
+// String is the string representation of the Ulcer Index.
+func (u *UlcerIndex[T]) String() string {
+	return fmt.Sprintf("ULCERINDEX(%d)", u.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volatility/ulcer_index_test.go
+++ b/volatility/ulcer_index_test.go
@@ -37,3 +37,12 @@ func TestUlcerIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUlcerIndexString(t *testing.T) {
+	expected := "ULCERINDEX(14)"
+	actual := volatility.NewUlcerIndex[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/ad.go
+++ b/volume/ad.go
@@ -50,6 +50,11 @@ func (*Ad[T]) IdlePeriod() int {
 	return 0
 }
 
+// String is the string representation of the A/D.
+func (*Ad[T]) String() string {
+	return "AD"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/volume/ad_test.go
+++ b/volume/ad_test.go
@@ -41,3 +41,12 @@ func TestAd(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAdString(t *testing.T) {
+	expected := "AD"
+	actual := volume.NewAd[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/cmf.go
+++ b/volume/cmf.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -65,6 +66,11 @@ func (c *Cmf[T]) ComputeWithContext(ctx context.Context, highs, lows, closings, 
 // IdlePeriod is the initial period that CMF won't yield any results.
 func (c *Cmf[T]) IdlePeriod() int {
 	return c.Sum.IdlePeriod()
+}
+
+// String is the string representation of the CMF.
+func (c *Cmf[T]) String() string {
+	return fmt.Sprintf("CMF(%d)", c.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/cmf_test.go
+++ b/volume/cmf_test.go
@@ -41,3 +41,12 @@ func TestCmf(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCmfString(t *testing.T) {
+	expected := "CMF(20)"
+	actual := volume.NewCmf[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/emv.go
+++ b/volume/emv.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -83,6 +84,11 @@ func (e *Emv[T]) ComputeWithContext(ctx context.Context, highs, lows, volumes <-
 // IdlePeriod is the initial period that EMV won't yield any results.
 func (e *Emv[T]) IdlePeriod() int {
 	return e.Sma.IdlePeriod() + 1
+}
+
+// String is the string representation of the EMV.
+func (e *Emv[T]) String() string {
+	return fmt.Sprintf("EMV(%d)", e.Sma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/emv_test.go
+++ b/volume/emv_test.go
@@ -39,3 +39,12 @@ func TestEmv(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestEmvString(t *testing.T) {
+	expected := "EMV(14)"
+	actual := volume.NewEmv[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/fi.go
+++ b/volume/fi.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -55,6 +56,11 @@ func (f *Fi[T]) ComputeWithContext(ctx context.Context, closings, volumes <-chan
 // IdlePeriod is the initial period that FI won't yield any results.
 func (f *Fi[T]) IdlePeriod() int {
 	return f.Ema.IdlePeriod() + 1
+}
+
+// String is the string representation of the FI.
+func (f *Fi[T]) String() string {
+	return fmt.Sprintf("FI(%d)", f.Ema.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/fi_test.go
+++ b/volume/fi_test.go
@@ -37,3 +37,12 @@ func TestFi(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestFiString(t *testing.T) {
+	expected := "FI(13)"
+	actual := volume.NewFi[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/kvo.go
+++ b/volume/kvo.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -102,6 +103,11 @@ func (k *Kvo[T]) ComputeWithContext(ctx context.Context, highs, lows, volumes <-
 // IdlePeriod is the initial period that KVO won't yield any results.
 func (k *Kvo[T]) IdlePeriod() int {
 	return k.LongEma.IdlePeriod() + k.SignalEma.IdlePeriod() + 1
+}
+
+// String is the string representation of the KVO.
+func (k *Kvo[T]) String() string {
+	return fmt.Sprintf("KVO(%d,%d,%d)", k.ShortEma.Period, k.LongEma.Period, k.SignalEma.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/kvo_test.go
+++ b/volume/kvo_test.go
@@ -60,3 +60,12 @@ func TestKvoIdlePeriod(t *testing.T) {
 		t.Fatalf("Expected %d, got %d", expected, actual)
 	}
 }
+
+func TestKvoString(t *testing.T) {
+	expected := "KVO(34,55,13)"
+	actual := volume.NewKvo[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/mfi.go
+++ b/volume/mfi.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -89,6 +90,11 @@ func (m *Mfi[T]) ComputeWithContext(ctx context.Context, highs, lows, closings, 
 // IdlePeriod is the initial period that MFI won't yield any results.
 func (m *Mfi[T]) IdlePeriod() int {
 	return m.Sum.IdlePeriod() + 1
+}
+
+// String is the string representation of the MFI.
+func (m *Mfi[T]) String() string {
+	return fmt.Sprintf("MFI(%d)", m.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/mfi_test.go
+++ b/volume/mfi_test.go
@@ -41,3 +41,12 @@ func TestMfi(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMfiString(t *testing.T) {
+	expected := "MFI(14)"
+	actual := volume.NewMfi[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/mfm.go
+++ b/volume/mfm.go
@@ -49,6 +49,11 @@ func (*Mfm[T]) IdlePeriod() int {
 	return 0
 }
 
+// String is the string representation of the MFM.
+func (*Mfm[T]) String() string {
+	return "MFM"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/volume/mfm_test.go
+++ b/volume/mfm_test.go
@@ -39,3 +39,12 @@ func TestMfm(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMfmString(t *testing.T) {
+	expected := "MFM"
+	actual := volume.NewMfm[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/mfv.go
+++ b/volume/mfv.go
@@ -46,6 +46,11 @@ func (*Mfv[T]) IdlePeriod() int {
 	return 0
 }
 
+// String is the string representation of the MFV.
+func (*Mfv[T]) String() string {
+	return "MFV"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/volume/mfv_test.go
+++ b/volume/mfv_test.go
@@ -41,3 +41,12 @@ func TestMfv(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMfvString(t *testing.T) {
+	expected := "MFV"
+	actual := volume.NewMfv[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/nvi.go
+++ b/volume/nvi.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 )
@@ -70,6 +71,11 @@ func (n *Nvi[T]) ComputeWithContext(ctx context.Context, closings, volumes <-cha
 // IdlePeriod is the initial period that NVI won't yield any results.
 func (*Nvi[T]) IdlePeriod() int {
 	return 1
+}
+
+// String is the string representation of the NVI.
+func (n *Nvi[T]) String() string {
+	return fmt.Sprintf("NVI(%v)", n.Initial)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/nvi_test.go
+++ b/volume/nvi_test.go
@@ -37,3 +37,12 @@ func TestNvi(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestNviString(t *testing.T) {
+	expected := "NVI(1000)"
+	actual := volume.NewNvi[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/obv.go
+++ b/volume/obv.go
@@ -54,6 +54,11 @@ func (*Obv[T]) IdlePeriod() int {
 	return 0
 }
 
+// String is the string representation of the OBV.
+func (*Obv[T]) String() string {
+	return "OBV"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/volume/obv_test.go
+++ b/volume/obv_test.go
@@ -37,3 +37,12 @@ func TestObv(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestObvString(t *testing.T) {
+	expected := "OBV"
+	actual := volume.NewObv[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/vpt.go
+++ b/volume/vpt.go
@@ -42,6 +42,11 @@ func (*Vpt[T]) IdlePeriod() int {
 	return 1
 }
 
+// String is the string representation of the VPT.
+func (*Vpt[T]) String() string {
+	return "VPT"
+}
+
 // Compute wraps ComputeWithContext for backwards compatibility.
 //
 // Deprecated: Use ComputeWithContext instead.

--- a/volume/vpt_test.go
+++ b/volume/vpt_test.go
@@ -37,3 +37,12 @@ func TestVpt(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestVptString(t *testing.T) {
+	expected := "VPT"
+	actual := volume.NewVpt[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/volume/vwap.go
+++ b/volume/vwap.go
@@ -6,6 +6,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/trend"
@@ -57,6 +58,11 @@ func (v *Vwap[T]) ComputeWithContext(ctx context.Context, closings, volumes <-ch
 // IdlePeriod is the initial period that VWAP won't yield any results.
 func (v *Vwap[T]) IdlePeriod() int {
 	return v.Sum.IdlePeriod()
+}
+
+// String is the string representation of the VWAP.
+func (v *Vwap[T]) String() string {
+	return fmt.Sprintf("VWAP(%d)", v.Sum.Period)
 }
 
 // Compute wraps ComputeWithContext for backwards compatibility.

--- a/volume/vwap_test.go
+++ b/volume/vwap_test.go
@@ -37,3 +37,12 @@ func TestVwap(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestVwapString(t *testing.T) {
+	expected := "VWAP(14)"
+	actual := volume.NewVwap[float64]().String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `String() string` to 58 exported indicator types across `trend`, `momentum`, `volatility`, and `volume` that lacked one, matching the existing convention used by `Ema`, `Sma`, `Kst`, `ZScore`, etc. (short abbreviation + parenthesized configurable parameters, e.g. `MACD(12,26,9)`).
- Breakdown: trend 23, momentum 13, volatility 11, volume 12.
- `volatility.ZScore` already had a `String()` method and was correctly left untouched.
- `trend.PivotPointResult` was intentionally skipped: it's a plain computed-value struct (P/R1-4/S1-4), not a configurable indicator, so a `String()` wouldn't fit the established convention.
- Purely additive: no existing method signatures, behavior, or fixtures changed.

## Test plan
- [x] Added a `TestXxxString` (or `TestXxxString`-style) unit test for every new `String()` method, following this codebase's existing test conventions.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no file touched by this change appears in the output (pre-existing unformatted files under `examples/`, `backtest/`, `strategy/` are unrelated and untouched).
- [x] `go test ./...` — all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp