### PR TITLE
Fix missing uint8 bit size in kindToBits map

### DIFF
--- a/helper/reflect.go
+++ b/helper/reflect.go
@@ -20,6 +20,7 @@ var kindToBits = map[reflect.Kind]int{
 	reflect.Int32:   32,
 	reflect.Int64:   64,
 	reflect.Uint:    bits.UintSize,
+	reflect.Uint8:   8,
 	reflect.Uint16:  16,
 	reflect.Uint32:  32,
 	reflect.Uint64:  64,

--- a/helper/reflect_test.go
+++ b/helper/reflect_test.go
@@ -225,6 +225,35 @@ func TestSetReflectValueFromNotUint8(t *testing.T) {
 	}
 }
 
+func TestSetReflectValueFromUint8Max(t *testing.T) {
+	actual := uint8(0)
+	value := reflect.ValueOf(&actual).Elem()
+	expected := uint8(255)
+
+	err := setReflectValue(value, "255", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}
+
+func TestSetReflectValueFromUint8OutOfRange(t *testing.T) {
+	actual := uint8(0)
+	value := reflect.ValueOf(&actual).Elem()
+
+	err := setReflectValue(value, "300", "")
+	if err == nil {
+		t.Fatalf("actual %v expected error", actual)
+	}
+
+	if actual != 0 {
+		t.Fatalf("actual %v expected value to remain unset", actual)
+	}
+}
+
 func TestSetReflectValueFromUint16(t *testing.T) {
 	actual := uint16(0)
 	value := reflect.ValueOf(&actual).Elem()


### PR DESCRIPTION
## Summary
- `helper/reflect.go`'s `kindToBits` map omitted `reflect.Uint8`, so `strconv.ParseUint`/`SetUint` used the platform default bit width instead of 8 when populating a `uint8` struct field from CSV
- Out-of-range values (e.g. `300`) parsed successfully at the wider width and were then silently truncated by `SetUint`, corrupting data instead of returning an error
- Added `reflect.Uint8: 8` to the map so out-of-range values now correctly fail with a parse error

## Test plan
- Added `TestSetReflectValueFromUint8Max` (boundary value 255 round-trips correctly)
- Added `TestSetReflectValueFromUint8OutOfRange` (value 300 now returns a parse error instead of truncating)
- `go build ./...`, `go vet ./...`, `gofmt -l .` (no touched files), `go test ./...` all pass