### PR TITLE
Fix WriteToFileWithContext stale bytes on shorter overwrite

### DIFF
--- a/helper/csv.go
+++ b/helper/csv.go
@@ -256,7 +256,7 @@ func (c *Csv[T]) WriteToFile(fileName string, rows <-chan *T) error {
 // WriteToFileWithContext creates a new file with the given name and writes the provided rows
 // of data to it, overwriting any existing content, supporting context cancellation.
 func (c *Csv[T]) WriteToFileWithContext(ctx context.Context, fileName string, rows <-chan *T) error {
-	file, err := os.OpenFile(filepath.Clean(fileName), os.O_CREATE|os.O_WRONLY, 0o600)
+	file, err := os.OpenFile(filepath.Clean(fileName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/helper/csv_test.go
+++ b/helper/csv_test.go
@@ -6,6 +6,7 @@ package helper_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -238,6 +239,52 @@ func TestCsvWriteToFile(t *testing.T) {
 	err = helper.CheckEquals(actual, expected)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCsvWriteToFileOverwritesShorterContent(t *testing.T) {
+	type Row struct {
+		Close float64
+		High  float64
+	}
+
+	longInput := []*Row{
+		{Close: 10, High: 20},
+		{Close: 30, High: 40},
+		{Close: 50, High: 60},
+	}
+
+	shortInput := []*Row{
+		{Close: 70, High: 80},
+	}
+
+	csv, err := helper.NewCsv[Row]()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileName := "test_csv_write_to_file_overwrites_shorter_content.csv"
+	defer helper.Remove(t, fileName)
+
+	err = csv.WriteToFile(fileName, helper.SliceToChan(longInput))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = csv.WriteToFile(fileName, helper.SliceToChan(shortInput))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Close,High\n70,80\n"
+
+	if string(actual) != expected {
+		t.Fatalf("actual %q expected %q", string(actual), expected)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `(*Csv[T]) WriteToFileWithContext` opened the destination file with `os.O_CREATE|os.O_WRONLY` but no `os.O_TRUNC`, so overwriting an existing file with shorter content left stale trailing bytes from the previous write in place, corrupting the resulting CSV (the doc comment promises "overwriting any existing content").
- Add `os.O_TRUNC` to the `os.OpenFile` flags. `AppendToFileWithContext` is untouched — it correctly uses `os.O_APPEND`.

## Test plan
- Added `TestCsvWriteToFileOverwritesShorterContent` in `helper/csv_test.go`: writes a longer CSV, then writes shorter content to the same file, and asserts the file's raw bytes equal exactly the shorter content.
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (clean for the changed files; pre-existing unrelated formatting warnings elsewhere are unchanged from master)
- `go test ./...`
