### PR TITLE
Document OBV's first-bar volume convention

### DIFF
--- a/volume/obv.go
+++ b/volume/obv.go
@@ -22,6 +22,12 @@ import (
 //
 //	obv := volume.NewObv[float64]()
 //	result := obv.Compute(closings, volumes)
+//
+// Note that the first emitted value, OBV[0], includes the full first-bar volume rather than starting at exactly
+// 0. This is because there is no true "previous close" for the very first bar, so the zero-valued previousClosing
+// causes the first comparison to read as an increase by default. This is inconsequential for typical OBV usage,
+// such as slope or trend analysis, since it only introduces a constant offset to the series rather than changing
+// its shape.
 type Obv[T helper.Number] struct{}
 
 // NewObv function initializes a new OBV instance with the default parameters.
@@ -30,6 +36,9 @@ func NewObv[T helper.Number]() *Obv[T] {
 }
 
 // ComputeWithContext function takes a channel of numbers and computes the OBV.
+//
+// Note that the first result includes the full first-bar volume rather than 0, since previousClosing starts at
+// its zero value and there is no real prior close to compare against for the first bar.
 func (i *Obv[T]) ComputeWithContext(ctx context.Context, closings, volumes <-chan T) <-chan T {
 	var previousClosing T
 	var previousObv T


### PR DESCRIPTION
## Summary
- Adds a doc comment to `volume/obv.go`'s `Obv` type and `ComputeWithContext` method noting that `OBV[0]` includes the full first-bar volume rather than starting at exactly `0`.
- This happens because the zero-valued `previousClosing` on bar 0 makes the first close-vs-previous comparison read as "up" by default, so bar 0's entire volume gets added instead of the running total starting at zero.
- Documented as a deliberate/inherent consequence of there being no true "previous close" for the very first bar, and noted as inconsequential for typical OBV usage (slope/trend analysis) since it only introduces a constant offset, not a shape change.
- Pure documentation fix: no code logic changed.

## Test plan
- [x] `git diff` confirms only comments changed in `volume/obv.go`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — `volume/obv.go` does not appear in the output (pre-existing unrelated formatting gaps in `examples/`/`backtest/`/`strategy/` untouched)
- [x] `go test ./...` — all packages pass, zero fixture changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp