### PR TITLE
Document SuperTrend's default HMA-based ATR smoothing

### DIFF
--- a/volatility/super_trend.go
+++ b/volatility/super_trend.go
@@ -38,6 +38,11 @@ const (
 //
 //	UpTrend = If (SuperTrend == FinalUpperBand) Then True Else False
 //
+// By default, the underlying ATR is smoothed using HMA (Hull Moving Average) rather than the more
+// textbook SMA/RMA, so that Super Trend reacts faster to price changes. This comes at the cost of a
+// longer idle period, e.g. 17 for a period of 14, versus 14 for a textbook SMA-based ATR of the same
+// period. Use NewSuperTrendWithMa to use a different moving average, such as SMA or RMA.
+//
 // Example:
 type SuperTrend[T helper.Number] struct {
 	Atr        *Atr[T]
@@ -55,6 +60,10 @@ func NewSuperTrend[T helper.Number]() *SuperTrend[T] {
 }
 
 // NewSuperTrendWithPeriod initializes a new Super Trend instance with the given period and multiplier.
+//
+// The ATR used internally is built with HMA smoothing (not the textbook SMA/RMA), which increases
+// the effective idle period, e.g. 17 rather than 14 for the default period of 14. Use
+// NewSuperTrendWithMa directly if a different moving average, such as SMA or RMA, is desired.
 func NewSuperTrendWithPeriod[T helper.Number](period int, multiplier T) *SuperTrend[T] {
 	return NewSuperTrendWithMa[T](
 		trend.NewHmaWithPeriod[T](period),


### PR DESCRIPTION
## Summary
- `NewSuperTrendWithPeriod` builds its internal ATR using HMA (Hull Moving Average) smoothing rather than the more textbook SMA/RMA, and this was undocumented.
- This is a real, consequential difference: it increases the effective idle period (17 vs. the textbook ATR's 14 for period 14), since HMA needs a longer warm-up than SMA/RMA.
- Documents the default on `SuperTrend`'s type doc comment and on `NewSuperTrendWithPeriod`, and points callers who want a different moving average to the existing `NewSuperTrendWithMa` constructor.
- Pure documentation change — no behavior/logic change. Changing the actual default would itself be a breaking change and is explicitly not done here.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` shows no new/changed findings for `volatility/super_trend.go`
- [x] `go test ./...` passes with zero fixture changes
- [x] `git diff` confirms only comments were added/changed in `volatility/super_trend.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp