### PR TITLE
Fix Macd silently misaligning output on reversed periods

### DIFF
--- a/trend/macd.go
+++ b/trend/macd.go
@@ -28,6 +28,11 @@ const (
 //	MACD = 12-Period EMA - 26-Period EMA.
 //	Signal = 9-Period EMA of MACD.
 //
+// Ema1's period (the "fast" period) must be less than Ema2's period (the
+// "slow" period) for the MACD line to align its two EMA streams correctly.
+// NewMacdWithPeriod automatically swaps period1 and period2 when they are
+// given in the wrong order, so Ema1 always ends up shorter than Ema2.
+//
 // Example:
 //
 //	macd := trend.NewMacd[float64]()
@@ -47,8 +52,17 @@ func NewMacd[T helper.Float]() *Macd[T] {
 	)
 }
 
-// NewMacdWithPeriod function initializes a new MACD instance with the given parameters.
+// NewMacdWithPeriod function initializes a new MACD instance with the given
+// parameters. The fast period (period1) must be less than the slow period
+// (period2) for the two EMA streams to align correctly when the MACD line
+// is computed. If period1 is greater than period2, the two are swapped so
+// that the resulting instance is always well-formed regardless of the
+// order the caller passes them in.
 func NewMacdWithPeriod[T helper.Float](period1, period2, period3 int) *Macd[T] {
+	if period1 > period2 {
+		period1, period2 = period2, period1
+	}
+
 	return &Macd[T]{
 		Ema1: NewEmaWithPeriod[T](period1),
 		Ema2: NewEmaWithPeriod[T](period2),

--- a/trend/macd_test.go
+++ b/trend/macd_test.go
@@ -56,3 +56,61 @@ func TestMacdString(t *testing.T) {
 		t.Fatalf("actual %v expected %v", actual, expected)
 	}
 }
+
+// TestMacdWithReversedPeriods asserts that constructing a Macd with the
+// fast and slow periods passed in reversed order (period1 > period2) is
+// automatically normalized, and behaves identically to constructing it
+// with the periods in the correct order.
+func TestMacdWithReversedPeriods(t *testing.T) {
+	type Data struct {
+		Close  float64
+		Macd   float64
+		Signal float64
+	}
+
+	input, err := helper.ReadFromCsvFile[Data]("testdata/macd.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	closing := helper.Map(input, func(d *Data) float64 { return d.Close })
+
+	// Passed in reversed order: slow period first, fast period second.
+	reversed := trend.NewMacdWithPeriod[float64](
+		trend.DefaultMacdPeriod2,
+		trend.DefaultMacdPeriod1,
+		trend.DefaultMacdPeriod3,
+	)
+
+	expected := "MACD(12,26,9)"
+	actual := reversed.String()
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+
+	actualMacds, actualSignals := reversed.Compute(closing)
+
+	actualMacds = helper.RoundDigits(actualMacds, 2)
+	actualSignals = helper.RoundDigits(actualSignals, 2)
+
+	inputs, err := helper.ReadFromCsvFile[Data]("testdata/macd.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedData := helper.Skip(inputs, reversed.IdlePeriod())
+
+	for data := range expectedData {
+		actualMacd := <-actualMacds
+		actualSignal := <-actualSignals
+
+		if actualMacd != data.Macd {
+			t.Fatalf("actual %v expected %v", actualMacd, data.Macd)
+		}
+
+		if actualSignal != data.Signal {
+			t.Fatalf("actual %v expected %v", actualSignal, data.Signal)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `NewMacdWithPeriod[T](period1, period2, period3)` did not validate that `period1 < period2` (fast period shorter than slow period).
- `ComputeWithContext` aligns the two EMA streams via `helper.SkipWithContext(ctx, emas1, Ema2.Period-Ema1.Period)`. When `period1 > period2` this skip count is negative, and `helper.SkipWithContext` is documented to be a no-op on a negative count (it never enters its skip loop) rather than panicking. The result: `emas1` is left unskipped and gets subtracted against `emas2` with no alignment, silently producing a misaligned/nonsensical MACD line instead of an error.
- Confirmed by tracing `helper/skip.go`'s `for i := 0; i < count; i++` loop, which is skipped entirely for negative `count`.
- Fix: `NewMacdWithPeriod` now swaps `period1`/`period2` whenever `period1 > period2`, before constructing the EMAs. This is preferred over a panic because it requires no signature change, can't break any existing correctly-ordered caller, and removes the landmine for every future caller (including anyone hitting it by accident) rather than just detecting it. Doc comments on `Macd` and `NewMacdWithPeriod` now state the `period1 < period2` requirement and the auto-normalization behavior explicitly.

## Test plan
- Added `TestMacdWithReversedPeriods` in `trend/macd_test.go`, constructing `Macd` with `(DefaultMacdPeriod2, DefaultMacdPeriod1, DefaultMacdPeriod3)` (i.e., slow/fast reversed) and asserting both `String()` and the computed MACD/signal values against `testdata/macd.csv` match the correctly-ordered case exactly.
- Verified `examples/trend/macd_strategy.go` (the only other caller of `NewMacdWithPeriod`) passes periods in the already-correct order, so it is unaffected by the swap.
- `go build ./...` passes.
- `go vet ./...` passes.
- `gofmt -l .` shows no new formatting issues introduced by this change (pre-existing unformatted files elsewhere in the repo are unrelated and unchanged, confirmed via `git stash`).
- `go test ./...` passes for all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp