### PR TITLE
Fix FileSystemRepository.Assets() listing directories as assets

### DIFF
--- a/asset/file_system_repository.go
+++ b/asset/file_system_repository.go
@@ -45,6 +45,10 @@ func (r *FileSystemRepository) Assets() ([]string, error) {
 	suffix := ".csv"
 
 	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
 		name := file.Name()
 
 		if strings.HasSuffix(name, suffix) {

--- a/asset/file_system_repository_test.go
+++ b/asset/file_system_repository_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"reflect"
 	"testing"
@@ -22,6 +23,27 @@ var repositoryBase = "testdata/repository"
 func TestFileSystemRepositoryAssets(t *testing.T) {
 	repository := asset.NewFileSystemRepository(repositoryBase)
 	expected := []string{"brk-b", "empty"}
+
+	actual, err := repository.Assets()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}
+
+func TestFileSystemRepositoryAssetsSkipsDirectories(t *testing.T) {
+	repository := asset.NewFileSystemRepository(repositoryBase)
+	expected := []string{"brk-b", "empty"}
+
+	dirName := path.Join(repositoryBase, "subdir.csv")
+
+	if err := os.Mkdir(dirName, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer helper.RemoveAll(t, dirName)
 
 	actual, err := repository.Assets()
 	if err != nil {


### PR DESCRIPTION
## Summary
- `FileSystemRepository.Assets()` only checked whether an entry's name ended in `.csv`, without checking `file.IsDir()`. A directory whose name happened to end in `.csv` (e.g. `X.csv/`) was returned as an asset named `X`, which would then fail confusingly downstream in `Get`/`ReadFromCsvFile` when something tried to actually read it as a file.
- Added a `file.IsDir()` check so directory entries are skipped regardless of their name, same as any other non-`.csv` entry.
- Note: a separate claim about `Assets()` returning entries in unsorted/non-deterministic order was investigated and found to be a false positive — `os.ReadDir` is documented to return entries already sorted by filename, so ordering is untouched here.

## Test plan
- Added `TestFileSystemRepositoryAssetsSkipsDirectories`, which creates a directory named `subdir.csv` under the existing `testdata/repository` fixture directory alongside the real `.csv` files, and asserts `Assets()` returns only `["brk-b", "empty"]` (the directory is excluded). The test cleans up the directory it creates.
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (only pre-existing, unrelated files reported — confirmed identical before and after this change)
- `go test ./...` (all packages pass)