### PR TITLE
Document HMA's math.Round period-derivation as a variant choice

### DIFF
--- a/trend/hma.go
+++ b/trend/hma.go
@@ -25,6 +25,14 @@ const (
 //	WMA2 = WMA(period, values)
 //	WMA3 = WMA(sqrt(period), (2 * WMA1) - WMA2)
 //	HMA = WMA3
+//
+// Note on period derivation: reference HMA implementations vary in how they derive the WMA1 and WMA3
+// sub-periods from period/2 and sqrt(period). Some truncate period/2 (integer division) rather than
+// rounding it, while most round sqrt(period). This implementation rounds both (via math.Round in
+// NewHmaWithPeriod), which is a deliberate, internally consistent choice rather than a bug. For even
+// periods this matches the common truncating variants, but for odd periods it can yield a WMA1 length
+// one greater than a truncating implementation would use, which may explain small output differences
+// when cross-checking against another platform's HMA.
 type Hma[T helper.Number] struct {
 	// First WMA.
 	wma1 *Wma[T]
@@ -44,6 +52,7 @@ func NewHma[T helper.Number]() *Hma[T] {
 // NewHmaWithPeriod function initializes a new HMA instance with the given parameters.
 func NewHmaWithPeriod[T helper.Number](period int) *Hma[T] {
 	return &Hma[T]{
+		// Rounded rather than truncated; see the variant-choice note on the Hma type above.
 		wma1: NewWmaWithPeriod[T](int(math.Round(float64(period) / 2))),
 		wma2: NewWmaWithPeriod[T](period),
 		wma3: NewWmaWithPeriod[T](int(math.Round(math.Sqrt(float64(period))))),


### PR DESCRIPTION
## Summary
- Documents that `trend/hma.go`'s use of `math.Round` for both `period/2` and `sqrt(period)` when deriving the WMA1/WMA3 sub-periods is a deliberate, internally consistent choice, not a bug.
- Notes that reference HMA implementations vary here (some truncate `period/2` rather than rounding it, most round `sqrt(period)`), which can explain small output differences for odd period values when comparing this library's HMA against another platform's.
- No formula or behavior change — comment-only edit to `trend/hma.go`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l trend/hma.go` (clean; pre-existing unrelated gofmt findings elsewhere in the repo are untouched by this change)
- [x] `go test ./...` (all packages pass, zero fixture changes)
- [x] `git diff` confirms only comments were added/changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp