### PR TITLE
Fix ReportColumn.Value silently returning zero-value

### DIFF
--- a/helper/annotation_report_column.go
+++ b/helper/annotation_report_column.go
@@ -4,7 +4,10 @@
 
 package helper
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // annotationReportColumn is the annotation report column struct.
 type annotationReportColumn struct {
@@ -34,13 +37,19 @@ func (*annotationReportColumn) Role() string {
 	return "annotation"
 }
 
-// Value returns the next data value for the report column.
-func (c *annotationReportColumn) Value() string {
-	value := <-c.values
+// Value returns the next data value for the report column. It returns
+// an error when the backing channel is exhausted before the report's
+// time axis is, which would otherwise silently produce a "null" value.
+func (c *annotationReportColumn) Value() (string, error) {
+	value, ok := <-c.values
 
-	if value != "" {
-		return fmt.Sprintf("%q", value)
+	if !ok {
+		return "", errors.New("annotation report column: no more data available")
 	}
 
-	return "null"
+	if value != "" {
+		return fmt.Sprintf("%q", value), nil
+	}
+
+	return "null", nil
 }

--- a/helper/annotation_report_column_test.go
+++ b/helper/annotation_report_column_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+func TestAnnotationReportColumnValue(t *testing.T) {
+	values := helper.SliceToChan([]string{"buy", ""})
+	column := helper.NewAnnotationReportColumn(values)
+
+	value, err := column.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if value != `"buy"` {
+		t.Fatalf("value is %s, expected \"buy\"", value)
+	}
+
+	value, err = column.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if value != "null" {
+		t.Fatalf("value is %s, expected null", value)
+	}
+}
+
+func TestAnnotationReportColumnValueExhausted(t *testing.T) {
+	values := helper.SliceToChan([]string{"buy"})
+	column := helper.NewAnnotationReportColumn(values)
+
+	// Consume the only available value.
+	if _, err := column.Value(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The backing channel is now exhausted and closed.
+	_, err := column.Value()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/helper/numeric_report_column.go
+++ b/helper/numeric_report_column.go
@@ -36,7 +36,15 @@ func (*numericReportColumn[T]) Role() string {
 	return "data"
 }
 
-// Value returns the next data value for the report column.
-func (c *numericReportColumn[T]) Value() string {
-	return fmt.Sprintf("%v", <-c.values)
+// Value returns the next data value for the report column. It returns
+// an error when the backing channel is exhausted before the report's
+// time axis is, which would otherwise silently produce a zero value.
+func (c *numericReportColumn[T]) Value() (string, error) {
+	value, ok := <-c.values
+
+	if !ok {
+		return "", fmt.Errorf("report column %q: no more data available", c.name)
+	}
+
+	return fmt.Sprintf("%v", value), nil
 }

--- a/helper/numeric_report_column_test.go
+++ b/helper/numeric_report_column_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+func TestNumericReportColumnValue(t *testing.T) {
+	values := helper.SliceToChan([]float64{1, 2})
+	column := helper.NewNumericReportColumn("Close", values)
+
+	value, err := column.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if value != "1" {
+		t.Fatalf("value is %s, expected 1", value)
+	}
+}
+
+func TestNumericReportColumnValueExhausted(t *testing.T) {
+	values := helper.SliceToChan([]float64{1})
+	column := helper.NewNumericReportColumn("Close", values)
+
+	// Consume the only available value.
+	if _, err := column.Value(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The backing channel is now exhausted and closed.
+	_, err := column.Value()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/helper/report.go
+++ b/helper/report.go
@@ -35,8 +35,11 @@ type ReportColumn interface {
 	// Role returns the role of the report column.
 	Role() string
 
-	// Value returns the next data value for the report column.
-	Value() string
+	// Value returns the next data value for the report column. It
+	// returns a non-nil error when the column has no more data to
+	// provide, such as when its backing channel has been exhausted
+	// before the report's time axis has.
+	Value() (string, error)
 }
 
 // Report generates an HTML file containing an interactive chart that

--- a/helper/report_test.go
+++ b/helper/report_test.go
@@ -5,6 +5,7 @@
 package helper_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -71,6 +72,35 @@ func TestReportWriteToFileFailed(t *testing.T) {
 	report.AddColumn(helper.NewNumericReportColumn("Close", closes))
 
 	err = report.WriteToFile("")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestReportWriteToWriterShortColumn(t *testing.T) {
+	type Row struct {
+		Date  time.Time `format:"2006-01-02"`
+		Close float64
+	}
+
+	input, err := helper.ReadFromCsvFile[Row]("testdata/report.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dates := helper.Map(input, func(row *Row) time.Time { return row.Date })
+
+	// The Close column is deliberately shorter than the Date axis, so
+	// the report generation is expected to fail instead of silently
+	// producing a report with a truncated or zero-filled column.
+	closes := helper.SliceToChan([]float64{1, 2, 3})
+
+	report := helper.NewReport("Test Report", dates)
+	report.AddColumn(helper.NewNumericReportColumn("Close", closes))
+
+	var buffer bytes.Buffer
+
+	err = report.WriteToWriter(&buffer)
 	if err == nil {
 		t.Fatal("expected error")
 	}


### PR DESCRIPTION
## Summary

- **Breaking interface change**: `helper.ReportColumn.Value()` now returns `(string, error)` instead of `string`. Previously, `numericReportColumn[T].Value()` and `annotationReportColumn.Value()` read from an exhausted (closed) channel with `<-c.values`, which silently returns the zero value of `T` (or `""` for annotations) with no way to detect that the column ran out of data early — e.g. if a shorter derived column (such as `PercentRank`'s off-by-one-short output) were ever wired in directly as a report column, this would silently corrupt/truncate the generated report instead of failing loudly.
- Both `numericReportColumn[T].Value()` and `annotationReportColumn.Value()` now check the `ok` flag from the channel receive and return a clear error (`"report column %q: no more data available"` / `"annotation report column: no more data available"`) when exhausted.
- `helper/report.tmpl`'s `{{ .Value }}` invocation required **no changes** — confirmed end-to-end with a new test (`TestReportWriteToWriterShortColumn`) that `text/template` correctly propagates the error from a `(string, error)`-returning method, aborting `WriteToWriter`/`WriteToFile` with the underlying error instead of producing a corrupted report.

### Call sites updated

Searched the whole repo (`grep -rn "\.Value()"` and `grep -rn "func.*Value() string"`) for anything besides the two known implementations. Found none — `examples/`, `strategy/`, and `backtest/` only construct columns via `NewNumericReportColumn`/`NewAnnotationReportColumn` and never call `.Value()` directly, so no other file needed changes. Files touched:

- `helper/report.go` — `ReportColumn.Value()` signature change.
- `helper/numeric_report_column.go` — exhaustion check + error.
- `helper/annotation_report_column.go` — same fix (it had the identical channel-exhaustion issue, not just the numeric column).

## Test plan

- [x] Added `TestNumericReportColumnValueExhausted` and `TestAnnotationReportColumnValueExhausted` — confirm `Value()` returns a non-nil error once the backing channel is drained.
- [x] Added `TestReportWriteToWriterShortColumn` — end-to-end test generating a report with an intentionally short numeric column; confirms `WriteToWriter` now returns a clear error instead of silently succeeding with a truncated/corrupted report.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on all touched files (clean; pre-existing unrelated formatting diffs elsewhere in the repo are untouched by this change)
- [x] `go test ./...` (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp