### PR TITLE
Fix StochasticOscillator/WilliamsR assuming Max/Min share IdlePeriod

### DIFF
--- a/momentum/stochastic_oscillator.go
+++ b/momentum/stochastic_oscillator.go
@@ -55,13 +55,25 @@ func NewStochasticOscillator[T helper.Number]() *StochasticOscillator[T] {
 func (s *StochasticOscillator[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-chan T) (<-chan T, <-chan T) {
 	//	K = (Closing - Lowest Low) / (Highest High - Lowest Low) * 100
 	//	D = 3-Period SMA of K
+	maxIdlePeriod := s.Max.IdlePeriod()
+	minIdlePeriod := s.Min.IdlePeriod()
+
 	lowestSplice := helper.DuplicateWithContext(ctx, s.Min.ComputeWithContext(ctx, lows),
 		2,
 	)
 
 	highest := s.Max.ComputeWithContext(ctx, highs)
 
-	closings = helper.SkipWithContext(ctx, closings, s.Min.IdlePeriod())
+	// Max and Min are independently configurable, so their idle periods may differ. Align both
+	// branches on the larger of the two idle periods before combining them.
+	if maxIdlePeriod > minIdlePeriod {
+		lowestSplice[0] = helper.SkipWithContext(ctx, lowestSplice[0], maxIdlePeriod-minIdlePeriod)
+		lowestSplice[1] = helper.SkipWithContext(ctx, lowestSplice[1], maxIdlePeriod-minIdlePeriod)
+	} else if minIdlePeriod > maxIdlePeriod {
+		highest = helper.SkipWithContext(ctx, highest, minIdlePeriod-maxIdlePeriod)
+	}
+
+	closings = helper.SkipWithContext(ctx, closings, max(maxIdlePeriod, minIdlePeriod))
 
 	kSplice := helper.DuplicateWithContext(ctx, helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, closings, lowestSplice[0]),
 		helper.SubtractWithContext(ctx, highest, lowestSplice[1]),
@@ -79,7 +91,7 @@ func (s *StochasticOscillator[T]) ComputeWithContext(ctx context.Context, highs,
 
 // IdlePeriod is the initial period that Stochastic Oscillator won't yield any results.
 func (s *StochasticOscillator[T]) IdlePeriod() int {
-	return s.Max.IdlePeriod() + s.Sma.IdlePeriod()
+	return max(s.Max.IdlePeriod(), s.Min.IdlePeriod()) + s.Sma.IdlePeriod()
 }
 
 // String is the string representation of the Stochastic Oscillator.

--- a/momentum/stochastic_oscillator_test.go
+++ b/momentum/stochastic_oscillator_test.go
@@ -46,6 +46,36 @@ func TestStochasticOscillator(t *testing.T) {
 	}
 }
 
+// TestStochasticOscillatorDifferentMaxMinPeriods verifies that StochasticOscillator correctly
+// aligns the Max and Min branches when they are independently configured with different periods,
+// rather than assuming Max.IdlePeriod() == Min.IdlePeriod(). Expected values were derived by hand
+// (and cross-checked with an independent reference calculation) for this small synthetic input.
+func TestStochasticOscillatorDifferentMaxMinPeriods(t *testing.T) {
+	highs := helper.SliceToChan([]float64{10, 12, 11, 15, 14, 16})
+	lows := helper.SliceToChan([]float64{5, 6, 4, 7, 8, 9})
+	closings := helper.SliceToChan([]float64{8, 9, 7, 10, 11, 12})
+
+	so := momentum.NewStochasticOscillator[float64]()
+	so.Max.Period = 2
+	so.Min.Period = 3
+
+	if so.IdlePeriod() != 4 {
+		t.Fatalf("actual idle period %v expected %v", so.IdlePeriod(), 4)
+	}
+
+	actualK, actualD := so.Compute(highs, lows, closings)
+	actualK = helper.RoundDigits(actualK, 2)
+	actualD = helper.RoundDigits(actualD, 2)
+
+	expectedK := helper.SliceToChan([]float64{63.64, 55.56})
+	expectedD := helper.SliceToChan([]float64{51.89, 57.91})
+
+	err := helper.CheckEquals(actualK, expectedK, actualD, expectedD)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStochasticOscillatorString(t *testing.T) {
 	expected := "STOCHOSC(14,3)"
 	actual := momentum.NewStochasticOscillator[float64]().String()

--- a/momentum/williams_r.go
+++ b/momentum/williams_r.go
@@ -47,13 +47,25 @@ func NewWilliamsR[T helper.Float]() *WilliamsR[T] {
 
 // ComputeWithContext function takes a channel of numbers and computes the Williams R.
 func (w *WilliamsR[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-chan T) <-chan T {
+	maxIdlePeriod := w.Max.IdlePeriod()
+	minIdlePeriod := w.Min.IdlePeriod()
+
 	highestSplice := helper.DuplicateWithContext(ctx, w.Max.ComputeWithContext(ctx, highs),
 		2,
 	)
 
 	lowest := w.Min.ComputeWithContext(ctx, lows)
 
-	closings = helper.SkipWithContext(ctx, closings, w.Max.IdlePeriod())
+	// Max and Min are independently configurable, so their idle periods may differ. Align both
+	// branches on the larger of the two idle periods before combining them.
+	if maxIdlePeriod > minIdlePeriod {
+		lowest = helper.SkipWithContext(ctx, lowest, maxIdlePeriod-minIdlePeriod)
+	} else if minIdlePeriod > maxIdlePeriod {
+		highestSplice[0] = helper.SkipWithContext(ctx, highestSplice[0], minIdlePeriod-maxIdlePeriod)
+		highestSplice[1] = helper.SkipWithContext(ctx, highestSplice[1], minIdlePeriod-maxIdlePeriod)
+	}
+
+	closings = helper.SkipWithContext(ctx, closings, max(maxIdlePeriod, minIdlePeriod))
 
 	return helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, highestSplice[0], closings),
 		helper.SubtractWithContext(ctx, highestSplice[1], lowest),
@@ -64,7 +76,7 @@ func (w *WilliamsR[T]) ComputeWithContext(ctx context.Context, highs, lows, clos
 
 // IdlePeriod is the initial period that Williams R won't yield any results.
 func (w *WilliamsR[T]) IdlePeriod() int {
-	return w.Max.IdlePeriod()
+	return max(w.Max.IdlePeriod(), w.Min.IdlePeriod())
 }
 
 // String is the string representation of the Williams R.

--- a/momentum/williams_r_test.go
+++ b/momentum/williams_r_test.go
@@ -42,6 +42,32 @@ func TestWilliamsR(t *testing.T) {
 	}
 }
 
+// TestWilliamsRDifferentMaxMinPeriods verifies that WilliamsR correctly aligns the Max and Min
+// branches when they are independently configured with different periods, rather than assuming
+// Max.IdlePeriod() == Min.IdlePeriod(). Expected values were derived by hand (and cross-checked
+// with an independent reference calculation) for this small synthetic input.
+func TestWilliamsRDifferentMaxMinPeriods(t *testing.T) {
+	highs := helper.SliceToChan([]float64{10, 12, 11, 15, 14, 16})
+	lows := helper.SliceToChan([]float64{5, 6, 4, 7, 8, 9})
+	closings := helper.SliceToChan([]float64{8, 9, 7, 10, 11, 12})
+
+	wr := momentum.NewWilliamsR[float64]()
+	wr.Max.Period = 2
+	wr.Min.Period = 3
+
+	if wr.IdlePeriod() != 2 {
+		t.Fatalf("actual idle period %v expected %v", wr.IdlePeriod(), 2)
+	}
+
+	actual := helper.RoundDigits(wr.Compute(highs, lows, closings), 2)
+	expected := helper.SliceToChan([]float64{-62.5, -45.45, -36.36, -44.44})
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWilliamsRString(t *testing.T) {
 	expected := "WILLIAMSR(14)"
 	actual := momentum.NewWilliamsR[float64]().String()


### PR DESCRIPTION
## Summary

- `StochasticOscillator.ComputeWithContext` and `WilliamsR.ComputeWithContext` hardcoded the assumption that `Max.IdlePeriod() == Min.IdlePeriod()`. Since `Max`/`Min` are exported `*trend.MovingMax[T]`/`*trend.MovingMin[T]` fields, a caller can mutate `.Period` on one after construction, causing the Max-branch and Min-branch channels to start at different absolute input rows. The `Subtract`/`Divide` helpers zip by arrival order, so this silently misaligned the calculation instead of erroring.
- Both `ComputeWithContext` methods now compute `Max.IdlePeriod()`/`Min.IdlePeriod()` at call time, skip the shorter-idle branch by the difference to realign it with the longer one (the same idiom `IchimokuCloud` already uses for its conversion/base-line alignment), and skip `closings` by `max(Max.IdlePeriod(), Min.IdlePeriod())` instead of just one side's idle period.
- Both `IdlePeriod()` methods now correctly report `max(Max.IdlePeriod(), Min.IdlePeriod())` (plus `Sma.IdlePeriod()` for the oscillator's combined K/D idle period), instead of ignoring one side entirely.
- Default construction (100% of in-tree usage) still uses equal `Max`/`Min` periods, so behavior there is unchanged.

## Test plan

- [x] `TestStochasticOscillator` and `TestWilliamsR` (existing fixture-based tests) pass unmodified — confirms byte-identical output for the default equal-period case.
- [x] Added `TestStochasticOscillatorDifferentMaxMinPeriods` and `TestWilliamsRDifferentMaxMinPeriods`, which mutate `Max.Period`/`Min.Period` to different values after construction on a small synthetic input and assert against expected values derived by hand and cross-checked with an independent reference calculation.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean for all touched files
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp