### PR TITLE
Fix TD Sequential closeHistory memory leak on long streams

### DIFF
--- a/momentum/td_sequential.go
+++ b/momentum/td_sequential.go
@@ -107,9 +107,20 @@ func (t *TdSequential[T]) ComputeWithContext(ctx context.Context, closings <-cha
 
 		var currentBuySetup, currentSellSetup T
 		var buyCountdownCount, sellCountdownCount int
+		var historyCount int
 		inBuyCountdown := false
 		inSellCountdown := false
-		closeHistory := make([]T, 0, t.Lookback+t.CountdownLookback+1)
+
+		// closeHistory only ever needs to answer "what was the close
+		// maxLookback bars ago", so a bounded ring is enough. Growing an
+		// ever-appended slice here would leak memory on a long-running
+		// stream.
+		maxLookback := t.Lookback
+		if t.CountdownLookback > maxLookback {
+			maxLookback = t.CountdownLookback
+		}
+		historySize := maxLookback + 1
+		closeHistory := helper.NewRing[T](historySize)
 
 		for {
 			select {
@@ -129,8 +140,17 @@ func (t *TdSequential[T]) ComputeWithContext(ctx context.Context, closings <-cha
 				}
 			}
 
-			closeHistory = append(closeHistory, current)
-			if len(closeHistory) <= t.Lookback {
+			closeHistory.Put(current)
+
+			// historyCount tracks how many bars the ring has ever seen,
+			// saturating at historySize once the ring is full, so that it
+			// mirrors the ring's own notion of how many elements are
+			// currently addressable via At.
+			if historyCount < historySize {
+				historyCount++
+			}
+
+			if historyCount <= t.Lookback {
 				select {
 				case <-ctx.Done():
 					return
@@ -154,7 +174,7 @@ func (t *TdSequential[T]) ComputeWithContext(ctx context.Context, closings <-cha
 				continue
 			}
 
-			prevClose := closeHistory[len(closeHistory)-1-t.Lookback]
+			prevClose, _ := closeHistory.At(historyCount - 1 - t.Lookback)
 
 			// Setup phase - buy (close < close 4 bars ago)
 			if lessThan(current, prevClose) {
@@ -204,8 +224,8 @@ func (t *TdSequential[T]) ComputeWithContext(ctx context.Context, closings <-cha
 
 			// Countdown phase - buy (close <= close 2 bars ago)
 			if inBuyCountdown && buyCountdownCount < t.CountdownPeriod {
-				if len(closeHistory) > t.CountdownLookback {
-					cdPrevClose := closeHistory[len(closeHistory)-1-t.CountdownLookback]
+				if historyCount > t.CountdownLookback {
+					cdPrevClose, _ := closeHistory.At(historyCount - 1 - t.CountdownLookback)
 					if lessOrEqual(current, cdPrevClose) {
 						buyCountdownCount++
 					}
@@ -214,8 +234,8 @@ func (t *TdSequential[T]) ComputeWithContext(ctx context.Context, closings <-cha
 
 			// Countdown phase - sell (close >= close 2 bars ago)
 			if inSellCountdown && sellCountdownCount < t.CountdownPeriod {
-				if len(closeHistory) > t.CountdownLookback {
-					cdPrevClose := closeHistory[len(closeHistory)-1-t.CountdownLookback]
+				if historyCount > t.CountdownLookback {
+					cdPrevClose, _ := closeHistory.At(historyCount - 1 - t.CountdownLookback)
 					if greaterOrEqual(current, cdPrevClose) {
 						sellCountdownCount++
 					}

--- a/momentum/td_sequential_test.go
+++ b/momentum/td_sequential_test.go
@@ -5,6 +5,8 @@
 package momentum_test
 
 import (
+	"math"
+	"runtime"
 	"testing"
 
 	"github.com/cinar/indicator/v2/helper"
@@ -154,6 +156,102 @@ func TestTdSequentialCountdownCrossCancel(t *testing.T) {
 	// without cross-cancellation the count would climb back to 5.
 	if rows[25].buyCountdown != 0 {
 		t.Fatalf("row 25: buyCountdown = %v, want 0 (stays cancelled, not 5)", rows[25].buyCountdown)
+	}
+}
+
+// TestTdSequentialLongStreamMemoryBounded runs many thousands of bars
+// through TD Sequential and checks that heap usage does not grow with the
+// length of the stream. Prior to the fix, ComputeWithContext kept an
+// ever-appended closeHistory slice that retained every close it had ever
+// seen, even though only the last handful of bars were ever read from it -
+// a real memory leak on a long-running/streaming input. A properly bounded
+// buffer should only ever hold max(Lookback, CountdownLookback)+1 elements,
+// so processing a long stream should not noticeably grow the heap.
+func TestTdSequentialLongStreamMemoryBounded(t *testing.T) {
+	const barCount = 200_000
+
+	// Oscillating, slowly drifting series so that setups and countdowns
+	// actually trigger repeatedly throughout the stream, rather than the
+	// indicator sitting idle the whole time.
+	closings := make([]float64, barCount)
+	price := 100.0
+	for i := 0; i < barCount; i++ {
+		closings[i] = price + math.Sin(float64(i)/3.0)*5
+		price += 0.001
+	}
+
+	runtime.GC()
+	runtime.GC()
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	td := momentum.NewTdSequential[float64]()
+	buySetup, sellSetup, buyCountdown, sellCountdown := td.Compute(helper.SliceToChan(closings))
+
+	combined := helper.Operate4(buySetup, sellSetup, buyCountdown, sellCountdown,
+		func(bs, ss, bc, sc float64) tdSequentialRow {
+			return tdSequentialRow{
+				buySetup:      bs,
+				sellSetup:     ss,
+				buyCountdown:  bc,
+				sellCountdown: sc,
+			}
+		})
+
+	// Drain without accumulating the results, so the test only measures
+	// growth attributable to the indicator's own internal state, not to a
+	// results slice held by the test itself.
+	count := 0
+	var lastRow tdSequentialRow
+
+	for row := range combined {
+		count++
+		lastRow = row
+	}
+
+	if count != barCount {
+		t.Fatalf("processed %d rows, want %d", count, barCount)
+	}
+
+	runtime.GC()
+	runtime.GC()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// An unbounded closeHistory slice holding barCount float64s (plus the
+	// amortized doubling overhead of repeated append) would retain several
+	// MiB for this input size. A bounded ring buffer only ever holds a
+	// handful of elements, so allow a generous ceiling that would still
+	// fail on a regression to the unbounded slice.
+	const maxHeapGrowth = 2 << 20 // 2 MiB
+
+	if after.HeapAlloc > before.HeapAlloc {
+		grown := after.HeapAlloc - before.HeapAlloc
+		if grown > maxHeapGrowth {
+			t.Fatalf("heap grew by %d bytes processing %d bars, want <= %d bytes (closeHistory may be unbounded again)",
+				grown, barCount, maxHeapGrowth)
+		}
+	}
+
+	// Sanity check that the outputs stayed within their documented bounds
+	// at the end of the run, confirming the bounded buffer did not silently
+	// corrupt the setup/countdown logic on a long stream.
+	if lastRow.buySetup < 0 || lastRow.buySetup > momentum.DefaultTdSequentialSetupPeriod {
+		t.Fatalf("final buySetup = %v, want within [0, %v]", lastRow.buySetup, momentum.DefaultTdSequentialSetupPeriod)
+	}
+
+	if lastRow.sellSetup > 0 || lastRow.sellSetup < -momentum.DefaultTdSequentialSetupPeriod {
+		t.Fatalf("final sellSetup = %v, want within [%v, 0]", lastRow.sellSetup, -momentum.DefaultTdSequentialSetupPeriod)
+	}
+
+	if lastRow.buyCountdown < 0 || lastRow.buyCountdown > momentum.DefaultTdSequentialCountdownPeriod {
+		t.Fatalf("final buyCountdown = %v, want within [0, %v]", lastRow.buyCountdown, momentum.DefaultTdSequentialCountdownPeriod)
+	}
+
+	if lastRow.sellCountdown < 0 || lastRow.sellCountdown > momentum.DefaultTdSequentialCountdownPeriod {
+		t.Fatalf("final sellCountdown = %v, want within [0, %v]", lastRow.sellCountdown, momentum.DefaultTdSequentialCountdownPeriod)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TdSequential.ComputeWithContext` maintained `closeHistory` as a slice that was appended to on every bar and never pruned, even though only the last `max(Lookback, CountdownLookback)+1` closes were ever read back from it — an unbounded memory leak on long-running/streaming input.
- Replace `closeHistory` with a `helper.Ring[T]` sized exactly to the window the setup/countdown comparisons need, tracked via a saturating `historyCount` that mirrors the ring's own element count, so the existing index arithmetic (`len(closeHistory)-1-t.Lookback` / `-t.CountdownLookback`) maps 1:1 onto `closeHistory.At(historyCount-1-t.Lookback)` / `-t.CountdownLookback`.
- Pure memory-bound fix — no change to setup/countdown logic (the cap and cross-cancel behavior from the prior PR is untouched).

## Test plan
- Added `TestTdSequentialLongStreamMemoryBounded`, which runs 200,000 synthetic bars through the indicator and asserts heap growth stays under a 2 MiB ceiling (an unbounded `closeHistory` slice would retain several MiB for this input size), plus sanity-checks the final setup/countdown outputs stay within their documented bounds.
- Confirmed `TestTdSequential` (the existing fixture-based test against `testdata/td_sequential.csv`) passes with zero changes to the fixture or the test itself.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (clean on touched files), `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)