### PR TITLE
Fix CostBasisExitStrategy preventing break-even selling

### DIFF
--- a/examples/decorator/cost_basis_exit_strategy.go
+++ b/examples/decorator/cost_basis_exit_strategy.go
@@ -47,8 +47,8 @@ func (c *CostBasisExitStrategy) ComputeWithContext(ctx context.Context, snapshot
 			return strategy.Buy
 		}
 
-		// If the action is sell and the asset was bought at a lower amount, sell it as recommended.
-		if action == strategy.Sell && boughtAt != 0.0 && boughtAt < closing {
+		// If the action is sell and the asset was bought at or below the current amount, sell it as recommended.
+		if action == strategy.Sell && boughtAt != 0.0 && boughtAt <= closing {
 			boughtAt = 0.0
 			return strategy.Sell
 		}

--- a/examples/decorator/cost_basis_exit_strategy_test.go
+++ b/examples/decorator/cost_basis_exit_strategy_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	"github.com/cinar/indicator/v2/asset"
-	"github.com/cinar/indicator/v2/helper"
-	"github.com/cinar/indicator/v2/strategy"
 	"github.com/cinar/indicator/v2/examples/decorator"
 	"github.com/cinar/indicator/v2/examples/trend"
+	"github.com/cinar/indicator/v2/helper"
+	"github.com/cinar/indicator/v2/strategy"
 )
 
 func TestCostBasisExitStrategy(t *testing.T) {
@@ -63,5 +63,66 @@ func TestNoLossStrategyAlias(t *testing.T) {
 	s := decorator.NewNoLossStrategy(innerStrategy)
 	if s == nil {
 		t.Fatal("expected non-nil strategy")
+	}
+}
+
+// fixedActionsStrategy is a test double that ignores the snapshot values and emits a
+// predetermined sequence of actions, one per snapshot received. Any snapshot beyond the
+// end of the configured sequence results in Hold.
+type fixedActionsStrategy struct {
+	actions []strategy.Action
+}
+
+func (s *fixedActionsStrategy) Name() string {
+	return "fixedActionsStrategy"
+}
+
+func (s *fixedActionsStrategy) Compute(snapshots <-chan *asset.Snapshot) <-chan strategy.Action {
+	actions := make(chan strategy.Action)
+
+	go func() {
+		defer close(actions)
+
+		i := 0
+		for range snapshots {
+			if i < len(s.actions) {
+				actions <- s.actions[i]
+			} else {
+				actions <- strategy.Hold
+			}
+			i++
+		}
+	}()
+
+	return actions
+}
+
+func (s *fixedActionsStrategy) Report(_ <-chan *asset.Snapshot) *helper.Report {
+	return &helper.Report{}
+}
+
+// TestCostBasisExitStrategyBreakEven confirms that a Sell signal whose closing price is
+// exactly equal to the earlier Buy's closing price (break even) is honored as a Sell,
+// matching the type's documented "at or above the original purchase price" behavior.
+// Prior to the fix, the strict less-than comparison caused this case to emit Hold instead.
+func TestCostBasisExitStrategyBreakEven(t *testing.T) {
+	innerStrategy := &fixedActionsStrategy{
+		actions: []strategy.Action{strategy.Buy, strategy.Hold, strategy.Sell},
+	}
+
+	snapshots := helper.SliceToChan([]*asset.Snapshot{
+		{Close: 10},
+		{Close: 8},
+		{Close: 10},
+	})
+
+	costBasisExitStrategy := decorator.NewCostBasisExitStrategy(innerStrategy)
+
+	actual := costBasisExitStrategy.Compute(snapshots)
+	expected := helper.SliceToChan([]strategy.Action{strategy.Buy, strategy.Hold, strategy.Sell})
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
- `CostBasisExitStrategy.ComputeWithContext` used `boughtAt < closing` for its Sell condition, so a closing price exactly equal to the original purchase price (break-even) emitted Hold instead of Sell — contradicting the type's own doc comment, which says the asset "is only sold if its value is at or above the original purchase price."
- Changed the comparison to `boughtAt <= closing` so break-even closes now trigger Sell as documented.

## Test plan
- [x] Added `TestCostBasisExitStrategyBreakEven` in `examples/decorator/cost_basis_exit_strategy_test.go`, using a small `fixedActionsStrategy` test double to drive a synthetic Buy/Hold/Sell sequence where the Sell bar's closing price exactly matches the Buy bar's closing price, confirming Sell is now emitted (previously would have been Hold).
- [x] Verified the existing fixture-based test (`testdata/cost_basis_exit_strategy.csv`) still passes unchanged — the real BRK-B price series used there does not hit an exact break-even bar for this strategy, so no fixture regeneration was needed.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean for the two changed files; pre-existing unrelated import-order violations elsewhere in the repo are untouched)
- [x] `go test ./...`