### PR TITLE
Fix RVI ComputeWithContext ignoring ctx cancellation

### DIFF
--- a/momentum/rvi.go
+++ b/momentum/rvi.go
@@ -60,80 +60,84 @@ func NewRvi[T helper.Float]() *Rvi[T] {
 	}
 }
 
-// computeFir applies a 4-bar FIR filter with weights 1-2-2-1.
-func computeFir[T helper.Float](c <-chan T) <-chan T {
+// computeFir applies a 4-bar FIR filter with weights 1-2-2-1, propagating
+// ctx through every stage so the filter closes its output promptly on
+// cancellation instead of blocking on a stalled upstream channel.
+func computeFir[T helper.Float](ctx context.Context, c <-chan T) <-chan T {
 	// FIR with weights 1-2-2-1:
 	// output[n] = (1*input[n] + 2*input[n-1] + 2*input[n-2] + 1*input[n-3]) / 6
 
 	// Duplicate to get delayed versions
-	cs := helper.Duplicate(c, 4)
+	cs := helper.DuplicateWithContext(ctx, c, 4)
 
 	// Shift each copy to get delayed values
 	delayed0 := cs[0] // current
-	delayed1 := helper.Shift(cs[1], 1, 0)
-	delayed2 := helper.Shift(cs[2], 2, 0)
-	delayed3 := helper.Shift(cs[3], 3, 0)
+	delayed1 := helper.ShiftWithContext(ctx, cs[1], 1, 0)
+	delayed2 := helper.ShiftWithContext(ctx, cs[2], 2, 0)
+	delayed3 := helper.ShiftWithContext(ctx, cs[3], 3, 0)
 
 	// Apply weights: 1*current + 2*prev1 + 2*prev2 + 1*prev3
-	weighted := helper.Add(
-		helper.Add(delayed0, helper.MultiplyBy(delayed1, 2)),
-		helper.Add(helper.MultiplyBy(delayed2, 2), delayed3),
+	weighted := helper.AddWithContext(ctx,
+		helper.AddWithContext(ctx, delayed0, helper.MultiplyByWithContext(ctx, delayed1, 2)),
+		helper.AddWithContext(ctx, helper.MultiplyByWithContext(ctx, delayed2, 2), delayed3),
 	)
 
 	// Divide by sum of weights (6)
-	result := helper.MultiplyBy(weighted, T(1)/T(RviFirSum))
+	result := helper.MultiplyByWithContext(ctx, weighted, T(1)/T(RviFirSum))
 
 	// Skip first 3 values (FIR warmup)
-	return helper.Skip(result, RviFirPeriod-1)
+	return helper.SkipWithContext(ctx, result, RviFirPeriod-1)
 }
 
 // ComputeWithContext function takes channels of OHLC numbers and computes the
 // Relative Vigor Index and its signal line.
 func (r *Rvi[T]) ComputeWithContext(ctx context.Context, opens, highs, lows, closings <-chan T) (rviResult <-chan T, signalResult <-chan T) {
-	return r.computeSimple(opens, highs, lows, closings)
+	return r.computeSimple(ctx, opens, highs, lows, closings)
 }
 
 // computeSimple is a simpler implementation.
-func (r *Rvi[T]) computeSimple(opens, highs, lows, closings <-chan T) (rviResult <-chan T, signalResult <-chan T) {
-	// Collect inputs to allow multiple passes
-	openVals := helper.ChanToSlice(opens)
-	highVals := helper.ChanToSlice(highs)
-	lowVals := helper.ChanToSlice(lows)
-	closeVals := helper.ChanToSlice(closings)
-
-	// Create channels for each calculation
-	openChan := helper.SliceToChan(openVals)
-	highChan := helper.SliceToChan(highVals)
-	lowChan := helper.SliceToChan(lowVals)
-	closeChan := helper.SliceToChan(closeVals)
-
+//
+// It used to collect the OHLC channels into slices with helper.ChanToSlice
+// before streaming them back through helper.SliceToChan. That collection
+// step ignored ctx and read its source channel to completion with a plain
+// `for n := range c`, so on a channel that never closes (a genuinely
+// open-ended stream) the call would block forever with no way to cancel
+// it. Since each of opens/highs/lows/closings is only ever read once
+// below (there was never an actual need for the "multiple passes" the
+// collect step was collecting for), the fix removes the collect/replay
+// round-trip entirely and wires the *WithContext helpers directly onto
+// the input channels, matching how Fisher (momentum/fisher.go) streams.
+// Every stage now selects on ctx.Done(), so ComputeWithContext returns
+// immediately and both output channels close promptly as soon as ctx is
+// cancelled, even if the inputs never close.
+func (r *Rvi[T]) computeSimple(ctx context.Context, opens, highs, lows, closings <-chan T) (rviResult <-chan T, signalResult <-chan T) {
 	// Compute: Close - Open
-	numeratorRaw := helper.Subtract(closeChan, openChan)
+	numeratorRaw := helper.SubtractWithContext(ctx, closings, opens)
 
 	// Compute: High - Low
-	denominatorRaw := helper.Subtract(highChan, lowChan)
+	denominatorRaw := helper.SubtractWithContext(ctx, highs, lows)
 
 	// Apply 4-bar FIR filter
-	numeratorFir := computeFir(numeratorRaw)
-	denominatorFir := computeFir(denominatorRaw)
+	numeratorFir := computeFir(ctx, numeratorRaw)
+	denominatorFir := computeFir(ctx, denominatorRaw)
 
 	// Apply SMA to filtered values
 	smaNum := trend.NewSmaWithPeriod[T](r.Period)
 	smaDen := trend.NewSmaWithPeriod[T](r.Period)
 
-	smaNumerator := smaNum.Compute(numeratorFir)
-	smaDenominator := smaDen.Compute(denominatorFir)
+	smaNumerator := smaNum.ComputeWithContext(ctx, numeratorFir)
+	smaDenominator := smaDen.ComputeWithContext(ctx, denominatorFir)
 
 	// Divide: RVI = SMA(FIR(Numerator)) / SMA(FIR(Denominator))
-	rvi := helper.Divide(smaNumerator, smaDenominator)
+	rvi := helper.DivideWithContext(ctx, smaNumerator, smaDenominator)
 
-	rviSplice := helper.Duplicate(rvi, 2)
+	rviSplice := helper.DuplicateWithContext(ctx, rvi, 2)
 
 	// Compute signal line
 	signalSma := trend.NewSmaWithPeriod[T](r.SignalPeriod)
-	signalResult = signalSma.Compute(rviSplice[0])
+	signalResult = signalSma.ComputeWithContext(ctx, rviSplice[0])
 
-	return helper.Skip(rviSplice[1], r.SignalPeriod-1), signalResult
+	return helper.SkipWithContext(ctx, rviSplice[1], r.SignalPeriod-1), signalResult
 }
 
 // IdlePeriod is the initial period that RVI won't yield any results.

--- a/momentum/rvi_test.go
+++ b/momentum/rvi_test.go
@@ -5,8 +5,11 @@
 package momentum_test
 
 import (
+	"context"
 	"math"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cinar/indicator/v2/helper"
 	"github.com/cinar/indicator/v2/momentum"
@@ -55,6 +58,51 @@ func TestRviSimple(t *testing.T) {
 	}
 
 	t.Logf("RVI: %d values, Signal: %d values", len(rviSlice), len(signalSlice))
+}
+
+func TestRviCancellation(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Unbuffered, never-closing input channels, simulating a genuinely
+	// open-ended stream that nothing ever writes to or closes.
+	opens := make(chan float64)
+	highs := make(chan float64)
+	lows := make(chan float64)
+	closings := make(chan float64)
+
+	rvi := momentum.NewRvi[float64]()
+	rviResult, signalResult := rvi.ComputeWithContext(ctx, opens, highs, lows, closings)
+
+	cancel()
+
+	select {
+	case _, ok := <-rviResult:
+		if ok {
+			t.Fatal("RVI channel should not yield a value after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RVI channel did not close promptly after cancellation")
+	}
+
+	select {
+	case _, ok := <-signalResult:
+		if ok {
+			t.Fatal("Signal channel should not yield a value after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Signal channel did not close promptly after cancellation")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
 }
 
 func TestRviString(t *testing.T) {


### PR DESCRIPTION
## Summary
- `momentum.Rvi.ComputeWithContext` accepted a `context.Context` but never actually used it: `computeSimple` collected each OHLC input channel into a slice via `helper.ChanToSlice` (a plain, non-context-aware `for n := range c` loop) before replaying the slice back through `helper.SliceToChan`. On a genuinely open-ended input stream that never closes, that collection step — and therefore `ComputeWithContext` itself — would block forever with no way to cancel it.
- Checked `git log --follow -p -- momentum/rvi.go`: unlike `momentum/fisher.go` (which had a dedicated fix commit, #424, for dropped output / wrong IdlePeriod / a synchronous-compute deadlock), RVI's `computeSimple` was never a fallback after a reverted streaming attempt — it's been slice-collect-based since it was introduced in #322. The "simple" name is just descriptive, not a deliberate safety net.
- Each of `opens`/`highs`/`lows`/`closings` is read exactly once in `computeSimple` (once for the numerator subtraction, once for the denominator), so the collect/replay round-trip wasn't actually needed for "multiple passes" as the old comment claimed. This PR removes it entirely and wires the `*WithContext` helpers (`SubtractWithContext`, `DuplicateWithContext`, `ShiftWithContext`, `AddWithContext`, `MultiplyByWithContext`, `SkipWithContext`, `DivideWithContext`, `Sma.ComputeWithContext`) directly onto the input channels — the same fully-streaming style `fisher.go` already uses.
- Net effect: every stage of the pipeline now selects on `ctx.Done()`, so `ComputeWithContext` returns immediately (it no longer blocks the caller's goroutine at all, which it previously did even for finite input) and both output channels close promptly the moment `ctx` is cancelled, regardless of whether the input channels ever close. There is no residual goroutine-leak limitation here: nothing in the rewritten pipeline reads from a raw channel with a plain (non-`ctx`-aware) blocking loop anymore.
- No numeric/behavioral change for finite/batch usage: `TestRviSimple` passes unchanged with identical output (35 values for the existing 50-bar fixture).

## Test plan
- [x] Added `TestRviCancellation` in `momentum/rvi_test.go`, following the established pattern in `trend/aroon_test.go`: unbuffered, never-fed/never-closed input channels, cancel immediately after calling `ComputeWithContext`, assert both output channels close promptly (with a 1s timeout guard) and that `runtime.NumGoroutine()` doesn't grow beyond baseline+2 after the call.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — neither changed file (`momentum/rvi.go`, `momentum/rvi_test.go`) appears in the output; the pre-existing unformatted files under `examples/`, `backtest/`, `strategy/` are unrelated and untouched (verified the same 49 files show up with my changes stashed out).
- [x] `go test ./...` — all packages pass, including the existing `TestRviSimple`/`TestRviString`/`TestRviIdlePeriod` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp