### PR TITLE
Fix Ring/Shift/Buffered/SkipLast panicking on zero/negative size

### DIFF
--- a/helper/buffered.go
+++ b/helper/buffered.go
@@ -15,7 +15,15 @@ func Buffered[T any](c <-chan T, size int) <-chan T {
 
 // BufferedWithContext takes a channel of any type and returns a new channel of the same type with
 // a buffer of the specified size with context support.
+//
+// A negative size is treated as zero: the returned channel is unbuffered
+// but still forwards every input value, matching SkipWithContext's
+// negative-count convention.
 func BufferedWithContext[T any](ctx context.Context, c <-chan T, size int) <-chan T {
+	if size < 0 {
+		size = 0
+	}
+
 	result := make(chan T, size)
 
 	go PipeWithContext(ctx, c, result)

--- a/helper/buffered_test.go
+++ b/helper/buffered_test.go
@@ -23,3 +23,15 @@ func TestBuffered(_ *testing.T) {
 
 	helper.Drain(b)
 }
+
+func TestBufferedNegativeSize(t *testing.T) {
+	input := helper.SliceToChan([]int{2, 4, 6, 8})
+	expected := helper.SliceToChan([]int{2, 4, 6, 8})
+
+	actual := helper.Buffered(input, -1)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/helper/echo.go
+++ b/helper/echo.go
@@ -14,6 +14,11 @@ func Echo[T any](input <-chan T, last, count int) <-chan T {
 }
 
 // EchoWithContext takes a channel of numbers, repeats the specified count of numbers at the end by the specified count, supporting context cancellation.
+//
+// A last of zero or less means there is nothing to replay: the repeat
+// phase emits no values regardless of count, and only the original
+// input is forwarded (NewRing clamps its backing ring to a minimum
+// size of 1 in this case, but that ring's contents are never read).
 func EchoWithContext[T any](ctx context.Context, input <-chan T, last, count int) <-chan T {
 	output := make(chan T)
 	memory := NewRing[T](last)

--- a/helper/echo_test.go
+++ b/helper/echo_test.go
@@ -22,6 +22,18 @@ func TestEcho(t *testing.T) {
 	}
 }
 
+func TestEchoZeroLast(t *testing.T) {
+	input := helper.SliceToChan([]int{2, 4, 6, 8})
+	expected := helper.SliceToChan([]int{2, 4, 6, 8})
+
+	actual := helper.Echo(input, 0, 4)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEchoShorterThanLast(t *testing.T) {
 	input := helper.SliceToChan([]int{2, 4})
 	expected := helper.SliceToChan([]int{2, 4, 2, 4, 2, 4})

--- a/helper/last.go
+++ b/helper/last.go
@@ -14,11 +14,31 @@ func Last[T any](c <-chan T, count int) <-chan T {
 }
 
 // LastWithContext takes a channel of values and returns a new channel containing the last N values, supporting context cancellation.
+//
+// A count of zero or less means there is nothing to keep: the input
+// channel is still drained, so upstream stages are not blocked, but no
+// values are emitted. (Unlike EchoWithContext, clamping a ring to a
+// minimum size of 1 would not be a safe stand-in here, since it would
+// wrongly surface one value instead of none, so this is guarded
+// explicitly rather than delegated to NewRing.)
 func LastWithContext[T any](ctx context.Context, c <-chan T, count int) <-chan T {
 	result := make(chan T, cap(c))
 
 	go func() {
 		defer close(result)
+
+		if count <= 0 {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case _, ok := <-c:
+					if !ok {
+						return
+					}
+				}
+			}
+		}
 
 		ring := NewRing[T](count)
 

--- a/helper/last_test.go
+++ b/helper/last_test.go
@@ -22,6 +22,30 @@ func TestLast(t *testing.T) {
 	}
 }
 
+func TestLastZeroCount(t *testing.T) {
+	input := helper.SliceToChan([]int{1, 2, 3, 4})
+	expected := helper.SliceToChan([]int{})
+
+	actual := helper.Last(input, 0)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLastNegativeCount(t *testing.T) {
+	input := helper.SliceToChan([]int{1, 2, 3, 4})
+	expected := helper.SliceToChan([]int{})
+
+	actual := helper.Last(input, -2)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLastLessValues(t *testing.T) {
 	input := helper.SliceToChan([]int{1, 2})
 	expected := helper.SliceToChan([]int{1, 2})

--- a/helper/ring.go
+++ b/helper/ring.go
@@ -23,8 +23,14 @@ type Ring[T any] struct {
 	count  int
 }
 
-// NewRing creates a new ring instance with the given size.
+// NewRing creates a new ring instance with the given size. A ring
+// cannot function with zero or negative capacity, so a size less than
+// 1 is clamped to 1.
 func NewRing[T any](size int) *Ring[T] {
+	if size < 1 {
+		size = 1
+	}
+
 	return &Ring[T]{
 		buffer: make([]T, size),
 		begin:  0,

--- a/helper/ring_test.go
+++ b/helper/ring_test.go
@@ -99,6 +99,37 @@ func TestRingAtPartiallyFilled(t *testing.T) {
 	}
 }
 
+func TestRingZeroSizeClampedToOne(t *testing.T) {
+	ring := helper.NewRing[int](0)
+
+	if ring.Put(1) != 0 {
+		t.Fatal("expected zero value evicted on first put")
+	}
+
+	actual, ok := ring.At(0)
+	if !ok {
+		t.Fatal("At(0) not ok")
+	}
+	if actual != 1 {
+		t.Fatalf("actual %v expected %v", actual, 1)
+	}
+
+	if !ring.IsFull() {
+		t.Fatal("expected ring of clamped size 1 to be full after one put")
+	}
+}
+
+func TestRingNegativeSizeClampedToOne(t *testing.T) {
+	ring := helper.NewRing[int](-1)
+
+	ring.Put(1)
+	actual := ring.Put(2)
+
+	if actual != 1 {
+		t.Fatalf("actual %v expected %v", actual, 1)
+	}
+}
+
 func TestRingAtFull(t *testing.T) {
 	ring := helper.NewRing[int](5)
 

--- a/helper/shift.go
+++ b/helper/shift.go
@@ -15,7 +15,15 @@ func Shift[T any](c <-chan T, count int, fill T) <-chan T {
 
 // ShiftWithContext takes a channel of numbers, shifts them to the right by the specified count,
 // and fills in any missing values with the provided fill value, supporting context cancellation.
+//
+// A negative count is treated as zero: no fill values are inserted, and
+// every input value is forwarded unchanged, matching SkipWithContext's
+// negative-count convention.
 func ShiftWithContext[T any](ctx context.Context, c <-chan T, count int, fill T) <-chan T {
+	if count < 0 {
+		count = 0
+	}
+
 	result := make(chan T, cap(c)+count)
 
 	go func() {

--- a/helper/shift_test.go
+++ b/helper/shift_test.go
@@ -21,3 +21,15 @@ func TestShift(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestShiftNegativeCount(t *testing.T) {
+	input := helper.SliceToChan([]int{2, 4, 6, 8})
+	expected := helper.SliceToChan([]int{2, 4, 6, 8})
+
+	actual := helper.Shift(input, -2, 0)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/helper/skip_last.go
+++ b/helper/skip_last.go
@@ -15,7 +15,15 @@ func SkipLast[T any](c <-chan T, count int) <-chan T {
 
 // SkipLastWithContext skips the specified number of elements
 // from the end of the given channel, supporting context cancellation.
+//
+// A negative count is treated as zero: nothing is skipped, and every
+// input value is forwarded unchanged, matching SkipWithContext's
+// negative-count convention.
 func SkipLastWithContext[T any](ctx context.Context, c <-chan T, count int) <-chan T {
+	if count < 0 {
+		count = 0
+	}
+
 	result := make(chan T, cap(c))
 
 	go func() {

--- a/helper/skip_last_test.go
+++ b/helper/skip_last_test.go
@@ -21,3 +21,15 @@ func TestSkipLast(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestSkipLastNegativeCount(t *testing.T) {
+	input := helper.SliceToChan([]int{2, 4, 6, 8})
+	expected := helper.SliceToChan([]int{2, 4, 6, 8})
+
+	actual := helper.SkipLast(input, -3)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- `helper.NewRing(0)` allocated a zero-capacity backing slice and panicked with an obscure index-out-of-range failure inside a later `Put` call, not at construction time. This was reachable via `EchoWithContext(..., last=0, ...)` and `LastWithContext(..., count=0, ...)`, which both forward `0` straight into `NewRing`.
- `ShiftWithContext`, `BufferedWithContext`, and `SkipLastWithContext` panicked on a negative `count`/`size` because it flowed into `make(chan T, cap(c)+count)` / `make(chan T, size)` / `make([]T, 0, count)`, and `make` panics on negative capacity.
- All of this is dormant: every in-tree caller already passes a valid, derived, positive value (confirmed via `grep`), but all four are exported public API reachable by external callers.

## Decisions
- **`NewRing(size)`**: clamped so any `size < 1` becomes `1`, documented explicitly in the doc comment. I chose clamp-over-panic (rather than an explicit `panic("helper: ring size must be positive")`) because it matches this codebase's established convention of favoring a sane degenerate-case default over a panic for exported API edge inputs (e.g. `Gcd`/`Lcm` returning `0` for empty input, `WindowWithContext` returning a closed empty channel for `w <= 0`, `CountActions` returning `ok=false` for zero strategies) — there's no other `NewX(size)`-style constructor in `helper/` to match, so I followed the package's broader precedent instead.
- **`ShiftWithContext`/`BufferedWithContext`/`SkipLastWithContext`**: a negative `count`/`size` is now treated as `0` — an explicit no-op (no shift, no extra buffer, no skip) — mirroring `SkipWithContext`'s existing negative-count behavior (its `for i := 0; i < count; i++` loop already short-circuits into a pure passthrough for negative `count`, just not documented as such before). Each doc comment now states this explicitly.
- **`EchoWithContext`**: with `last <= 0`, no doc/logic change to the replay loop was needed — its `for j := 0; j < last; j++` bound already emits nothing when `last <= 0`, so once `NewRing` stopped panicking, `Echo` was already correct. Added a doc comment making this explicit.
- **`LastWithContext`**: clamping `NewRing` to size 1 is *not* safe here — with `count <= 0`, the old code would have stored and then emitted exactly one value instead of zero, which is semantically wrong for "last 0 values". So `LastWithContext` now guards `count <= 0` explicitly up front: it drains the input channel (so an upstream stage is never blocked) but emits nothing, before ever touching `NewRing`.

## Test plan
- Added `TestRingZeroSizeClampedToOne` / `TestRingNegativeSizeClampedToOne` in `helper/ring_test.go`.
- Added `TestShiftNegativeCount`, `TestBufferedNegativeSize`, `TestSkipLastNegativeCount` asserting identical passthrough output to the unmodified input.
- Added `TestEchoZeroLast` (forwards input unchanged, no replay) and `TestLastZeroCount` / `TestLastNegativeCount` (empty output) in their respective test files.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (no output), `go test ./...`, and `go test ./helper/... -race` all pass.
- Scoped strictly to `helper/ring.go`, `helper/shift.go`, `helper/buffered.go`, `helper/skip_last.go`, `helper/echo.go`, `helper/last.go`, and their tests — no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp