### PR TITLE
Fix CommonPeriod panicking on empty input

### DIFF
--- a/helper/sync.go
+++ b/helper/sync.go
@@ -8,6 +8,7 @@ import "slices"
 
 // CommonPeriod calculates the largest period at which all data channels can be synchronized,
 // so that every channel has warmed up (skipped its own idle period) before values are compared.
+// It returns 0 for empty input.
 //
 // Example:
 //
@@ -23,6 +24,10 @@ import "slices"
 //	// Synchronize the third channel
 //	c3 := helper.Sync(commonPeriod, 3, c3)
 func CommonPeriod(periods ...int) int {
+	if len(periods) == 0 {
+		return 0
+	}
+
 	return slices.Max(periods)
 }
 

--- a/helper/sync_test.go
+++ b/helper/sync_test.go
@@ -31,3 +31,21 @@ func TestSync(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCommonPeriodWithEmptyInput(t *testing.T) {
+	actual := helper.CommonPeriod()
+	expected := 0
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}
+
+func TestCommonPeriodWithValues(t *testing.T) {
+	actual := helper.CommonPeriod(4, 2, 3)
+	expected := 4
+
+	if actual != expected {
+		t.Fatalf("actual %d expected %d", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- `helper.CommonPeriod(periods ...int) int` called `slices.Max(periods)` directly, which panics on an empty slice, so `CommonPeriod()` with zero arguments panics.
- This is dormant code with zero in-tree callers passing empty input today (`grep -rn "CommonPeriod("` finds 4 real call sites — 2 in `examples/trend/alligator_strategy.go`, 2 in `examples/trend/smma_strategy.go` — all pass non-empty periods), but `CommonPeriod` is exported public API, so external callers can hit the panic.
- Following the precedent set by the recent Gcd/Lcm fix (#465), `CommonPeriod` now returns `0` for empty input rather than changing its signature to return an error, keeping this a small, low-disruption fix consistent with that established convention.

## Test plan
- Added `TestCommonPeriodWithEmptyInput` in `helper/sync_test.go` confirming `CommonPeriod()` returns `0` instead of panicking.
- Added `TestCommonPeriodWithValues` confirming existing non-empty-input behavior (`CommonPeriod(4, 2, 3) == 4`) is unchanged.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (no output for touched files), `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp