### PR TITLE
Implement IsRising helper for detecting rising values

### DIFF
--- a/helper/is_rising.go
+++ b/helper/is_rising.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper
+
+import (
+	"context"
+)
+
+// IsRisingWithContext takes a channel of type T values and returns 1 if the current
+// value is strictly greater than the value the given period before, and 0 otherwise,
+// supporting context cancellation.
+//
+// Example:
+//
+//	input := []int{1, 2, 5, 5, 8, 2, 1, 1, 3, 4}
+//	output := helper.IsRising(helper.SliceToChan(input), 1)
+//	fmt.Println(helper.ChanToSlice(output)) // [1, 1, 0, 1, 0, 0, 0, 1, 1]
+func IsRisingWithContext[T Number](ctx context.Context, c <-chan T, period int) <-chan T {
+	cs := DuplicateWithContext(ctx, c, 2)
+	cs[0] = BufferedWithContext(ctx, cs[0], period)
+	cs[1] = SkipWithContext(ctx, cs[1], period)
+
+	return OperateWithContext(ctx, cs[1], cs[0], func(current, before T) T {
+		if current > before {
+			return 1
+		}
+
+		return 0
+	})
+}
+
+// IsRising wraps IsRisingWithContext for backwards compatibility.
+//
+// Deprecated: Use IsRisingWithContext instead.
+func IsRising[T Number](c <-chan T, period int) <-chan T {
+	return IsRisingWithContext(context.Background(), c, period)
+}

--- a/helper/is_rising_test.go
+++ b/helper/is_rising_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+func TestIsRising(t *testing.T) {
+	input := helper.SliceToChan([]int{1, 2, 5, 5, 8, 2, 1, 1, 3, 4})
+	expected := helper.SliceToChan([]int{1, 1, 0, 1, 0, 0, 0, 1, 1})
+
+	actual := helper.IsRising(input, 1)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsRisingWithPeriod(t *testing.T) {
+	input := helper.SliceToChan([]int{1, 2, 5, 5, 8, 2, 1, 1, 3, 4})
+	expected := helper.SliceToChan([]int{1, 1, 1, 0, 0, 0, 1, 1})
+
+	actual := helper.IsRising(input, 2)
+
+	err := helper.CheckEquals(actual, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
# Describe Request

Adds a generic `IsRising` / `IsRisingWithContext` helper to the `helper` package. It compares
each value in a channel against the value `period` steps before it, emitting `1` when the
current value is strictly greater and `0` otherwise (ties emit `0`).

Fixed #369

# Change Type

New feature (additive). One new file, `helper/is_rising.go`, plus its test. No existing code
or behavior is changed.

# Checklist

- [x] I have read and agree to the [Contributor License Agreement (CLA)](CLA.md).
- [x] My code adheres to the project's coding standards and includes comprehensive unit tests.
- [x] No external dependencies have been introduced.

## Notes for reviewers

- Follows the `XxxWithContext` + deprecated `Xxx` wrapper pattern used by 52 of the 54
  `WithContext` helpers in this package (`Change`, `Sign`, `Since`, ...) rather than the
  context-less signature written literally in the issue, since that convention was established
  after the issue was filed. The issue's exact signature is still available as `IsRising`.
- The implementation reuses `DuplicateWithContext` + `BufferedWithContext` + `SkipWithContext`
  + `OperateWithContext`, the same primitives `helper.Change` uses to pair a value with its
  lagged counterpart, so lag alignment, short-input handling, and context cancellation behave
  identically to `Change`.
- Like `Change`, the first `period` values produce no output, and `period` is a plain `int`
  (Go has no default arguments, so the issue's "default: 1" is documented for callers).
- New file is at 100% statement coverage; `go build`, `go vet`, `gofmt`, `revive`, and
  `go test -race ./...` all pass.
- I did not regenerate `helper/README.md`. It is gomarkdoc-generated, and running the generator
  locally rewrites pre-existing drift across every package's README that is unrelated to this
  change. Happy to include a regenerated `helper/README.md` if you'd prefer it in this PR.
