### PR TITLE
Tighten high-risk indicators to helper.Float

### DIFF
--- a/momentum/ibs.go
+++ b/momentum/ibs.go
@@ -20,10 +20,10 @@ import (
 //
 //	ibs := momentum.NewInternalBarStrength[float64]()
 //	result := ibs.Compute(highs, lows, closings)
-type InternalBarStrength[T helper.Number] struct{}
+type InternalBarStrength[T helper.Float] struct{}
 
 // NewInternalBarStrength function initializes a new InternalBarStrength instance.
-func NewInternalBarStrength[T helper.Number]() *InternalBarStrength[T] {
+func NewInternalBarStrength[T helper.Float]() *InternalBarStrength[T] {
 	return &InternalBarStrength[T]{}
 }
 

--- a/momentum/stochastic_oscillator.go
+++ b/momentum/stochastic_oscillator.go
@@ -31,7 +31,7 @@ const (
 //
 //	so := momentum.NewStochasticOscillator[float64]()
 //	k, d := so.Compute(highs, lows, closings)
-type StochasticOscillator[T helper.Number] struct {
+type StochasticOscillator[T helper.Float] struct {
 	// Max is the Moving Max instance.
 	Max *trend.MovingMax[T]
 
@@ -43,7 +43,7 @@ type StochasticOscillator[T helper.Number] struct {
 }
 
 // NewStochasticOscillator function initializes a new Stochastic Oscillator instance.
-func NewStochasticOscillator[T helper.Number]() *StochasticOscillator[T] {
+func NewStochasticOscillator[T helper.Float]() *StochasticOscillator[T] {
 	return &StochasticOscillator[T]{
 		Max: trend.NewMovingMaxWithPeriod[T](DefaultStochasticOscillatorMaxAndMinPeriod),
 		Min: trend.NewMovingMinWithPeriod[T](DefaultStochasticOscillatorMaxAndMinPeriod),

--- a/momentum/ultimate_oscillator.go
+++ b/momentum/ultimate_oscillator.go
@@ -40,7 +40,7 @@ const (
 //
 //	uo := momentum.NewUltimateOscillator[float64]()
 //	values := uo.Compute(highs, lows, closings)
-type UltimateOscillator[T helper.Number] struct {
+type UltimateOscillator[T helper.Float] struct {
 	// ShortPeriod is the short period for the UO.
 	ShortPeriod int
 
@@ -52,7 +52,7 @@ type UltimateOscillator[T helper.Number] struct {
 }
 
 // NewUltimateOscillator function initializes a new Ultimate Oscillator instance.
-func NewUltimateOscillator[T helper.Number]() *UltimateOscillator[T] {
+func NewUltimateOscillator[T helper.Float]() *UltimateOscillator[T] {
 	return NewUltimateOscillatorWithPeriods[T](
 		DefaultUltimateOscillatorShortPeriod,
 		DefaultUltimateOscillatorMediumPeriod,
@@ -61,7 +61,7 @@ func NewUltimateOscillator[T helper.Number]() *UltimateOscillator[T] {
 }
 
 // NewUltimateOscillatorWithPeriods function initializes a new Ultimate Oscillator instance with the given periods.
-func NewUltimateOscillatorWithPeriods[T helper.Number](shortPeriod, mediumPeriod, longPeriod int) *UltimateOscillator[T] {
+func NewUltimateOscillatorWithPeriods[T helper.Float](shortPeriod, mediumPeriod, longPeriod int) *UltimateOscillator[T] {
 	return &UltimateOscillator[T]{
 		ShortPeriod:  shortPeriod,
 		MediumPeriod: mediumPeriod,

--- a/trend/bop.go
+++ b/trend/bop.go
@@ -17,11 +17,11 @@ import (
 // between the two forces.
 //
 //	Formula: BOP = (Closing - Opening) / (High - Low)
-type Bop[T helper.Number] struct{}
+type Bop[T helper.Float] struct{}
 
 // NewBop function initializes a new BOP instance
 // with the default parameters.
-func NewBop[T helper.Number]() *Bop[T] {
+func NewBop[T helper.Float]() *Bop[T] {
 	return &Bop[T]{}
 }
 

--- a/trend/cfo.go
+++ b/trend/cfo.go
@@ -27,18 +27,18 @@ const (
 //
 //	cfo := trend.NewCfo[float64]()
 //	result := cfo.Compute(c)
-type Cfo[T helper.Number] struct {
+type Cfo[T helper.Float] struct {
 	// Mlr is the Moving Linear Regression instance.
 	Mlr *Mlr[T]
 }
 
 // NewCfo function initializes a new CFO instance with the default parameters.
-func NewCfo[T helper.Number]() *Cfo[T] {
+func NewCfo[T helper.Float]() *Cfo[T] {
 	return NewCfoWithPeriod[T](DefaultCfoPeriod)
 }
 
 // NewCfoWithPeriod function initializes a new CFO instance with the given period.
-func NewCfoWithPeriod[T helper.Number](period int) *Cfo[T] {
+func NewCfoWithPeriod[T helper.Float](period int) *Cfo[T] {
 	return &Cfo[T]{
 		Mlr: NewMlrWithPeriod[T](period),
 	}

--- a/trend/kama.go
+++ b/trend/kama.go
@@ -37,7 +37,7 @@ const (
 //
 //	kama := trend.NewKama[float64]()
 //	result := kama.Compute(c)
-type Kama[T helper.Number] struct {
+type Kama[T helper.Float] struct {
 	// ErPeriod is the Efficiency Ratio time period.
 	ErPeriod int
 
@@ -49,7 +49,7 @@ type Kama[T helper.Number] struct {
 }
 
 // NewKama function initializes a new KAMA instance with the default parameters.
-func NewKama[T helper.Number]() *Kama[T] {
+func NewKama[T helper.Float]() *Kama[T] {
 	return NewKamaWith[T](
 		DefaultKamaErPeriod,
 		DefaultKamaFastScPeriod,
@@ -58,7 +58,7 @@ func NewKama[T helper.Number]() *Kama[T] {
 }
 
 // NewKamaWith function initializes a new KAMA instance with the given parameters.
-func NewKamaWith[T helper.Number](erPeriod, fastScPeriod, slowScPeriod int) *Kama[T] {
+func NewKamaWith[T helper.Float](erPeriod, fastScPeriod, slowScPeriod int) *Kama[T] {
 	return &Kama[T]{
 		ErPeriod:     erPeriod,
 		FastScPeriod: fastScPeriod,

--- a/trend/kdj.go
+++ b/trend/kdj.go
@@ -43,7 +43,7 @@ const (
 //
 //	kdj := NewKdj[float64]()
 //	values := kdj.Compute(highs, lows, closings)
-type Kdj[T helper.Number] struct {
+type Kdj[T helper.Float] struct {
 	// MovingMax is the highest high.
 	MovingMax *MovingMax[T]
 
@@ -58,7 +58,7 @@ type Kdj[T helper.Number] struct {
 }
 
 // NewKdj function initializes a new Kdj instance with the default parameters
-func NewKdj[T helper.Number]() *Kdj[T] {
+func NewKdj[T helper.Float]() *Kdj[T] {
 	kdj := &Kdj[T]{
 		MovingMax: NewMovingMax[T](),
 		MovingMin: NewMovingMin[T](),

--- a/trend/slow_stochastic.go
+++ b/trend/slow_stochastic.go
@@ -34,7 +34,7 @@ const (
 //
 //	s := trend.NewSlowStochastic[float64]()
 //	k, d := s.Compute(values)
-type SlowStochastic[T helper.Number] struct {
+type SlowStochastic[T helper.Float] struct {
 	// Period is the period for the min/max calculation.
 	Period int
 
@@ -46,7 +46,7 @@ type SlowStochastic[T helper.Number] struct {
 }
 
 // NewSlowStochastic function initializes a new SlowStochastic instance with the default parameters.
-func NewSlowStochastic[T helper.Number]() *SlowStochastic[T] {
+func NewSlowStochastic[T helper.Float]() *SlowStochastic[T] {
 	return &SlowStochastic[T]{
 		Period:  DefaultSlowStochasticPeriod,
 		KPeriod: DefaultSlowStochasticKPeriod,
@@ -55,7 +55,7 @@ func NewSlowStochastic[T helper.Number]() *SlowStochastic[T] {
 }
 
 // NewSlowStochasticWithPeriod function initializes a new SlowStochastic instance with the given periods.
-func NewSlowStochasticWithPeriod[T helper.Number](period, kPeriod, dPeriod int) *SlowStochastic[T] {
+func NewSlowStochasticWithPeriod[T helper.Float](period, kPeriod, dPeriod int) *SlowStochastic[T] {
 	return &SlowStochastic[T]{
 		Period:  period,
 		KPeriod: kPeriod,

--- a/trend/stochastic.go
+++ b/trend/stochastic.go
@@ -32,7 +32,7 @@ const (
 //
 //	s := trend.NewStochastic[float64]()
 //	k, d := s.Compute(values)
-type Stochastic[T helper.Number] struct {
+type Stochastic[T helper.Float] struct {
 	// Period is the period for the min/max calculation.
 	Period int
 
@@ -41,12 +41,12 @@ type Stochastic[T helper.Number] struct {
 }
 
 // NewStochastic function initializes a new Stochastic instance with the default parameters.
-func NewStochastic[T helper.Number]() *Stochastic[T] {
+func NewStochastic[T helper.Float]() *Stochastic[T] {
 	return NewStochasticWithPeriod[T](DefaultStochasticPeriod)
 }
 
 // NewStochasticWithPeriod function initializes a new Stochastic instance with the given period.
-func NewStochasticWithPeriod[T helper.Number](period int) *Stochastic[T] {
+func NewStochasticWithPeriod[T helper.Float](period int) *Stochastic[T] {
 	return &Stochastic[T]{
 		Period: period,
 		Sma:    NewSmaWithPeriod[T](DefaultStochasticSmaPeriod),

--- a/trend/vwma.go
+++ b/trend/vwma.go
@@ -21,13 +21,13 @@ const (
 // greater weight.
 //
 //	VWMA = Sum(Price * Volume) / Sum(Volume)
-type Vwma[T helper.Number] struct {
+type Vwma[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewVwma function initializes a new VWMA instance with the default parameters.
-func NewVwma[T helper.Number]() *Vwma[T] {
+func NewVwma[T helper.Float]() *Vwma[T] {
 	return &Vwma[T]{
 		Period: DefaultVwmaPeriod,
 	}

--- a/volatility/acceleration_bands.go
+++ b/volatility/acceleration_bands.go
@@ -28,13 +28,13 @@ const (
 //
 //	accelerationBands := NewAccelerationBands[float64]()
 //	accelerationBands.Compute(values)
-type AccelerationBands[T helper.Number] struct {
+type AccelerationBands[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewAccelerationBands function initializes a new Acceleration Bands instance with the default parameters.
-func NewAccelerationBands[T helper.Number]() *AccelerationBands[T] {
+func NewAccelerationBands[T helper.Float]() *AccelerationBands[T] {
 	return &AccelerationBands[T]{
 		Period: DefaultAccelerationBandsPeriod,
 	}

--- a/volatility/bollinger_band_width.go
+++ b/volatility/bollinger_band_width.go
@@ -24,13 +24,13 @@ import (
 //
 //	bbw := NewBollingerBandWidth[float64]()
 //	bbw.Compute(c)
-type BollingerBandWidth[T helper.Number] struct {
+type BollingerBandWidth[T helper.Float] struct {
 	// Bollinger bands.
 	BollingerBands *BollingerBands[T]
 }
 
 // NewBollingerBandWidth function initializes a new Bollinger Band Width instance with the default parameters.
-func NewBollingerBandWidth[T helper.Number]() *BollingerBandWidth[T] {
+func NewBollingerBandWidth[T helper.Float]() *BollingerBandWidth[T] {
 	return &BollingerBandWidth[T]{
 		BollingerBands: NewBollingerBands[T](),
 	}

--- a/volatility/chop.go
+++ b/volatility/chop.go
@@ -23,18 +23,18 @@ const (
 // It is a technical analysis indicator that measures the market's trendiness or choppiness.
 //
 //	CHOP = 100 * LOG10( SUM(ATR(1), n) / (MAX(High, n) - MIN(Low, n)) ) / LOG10(n)
-type Chop[T helper.Number] struct {
+type Chop[T helper.Float] struct {
 	// Period is the period for the CHOP.
 	Period int
 }
 
 // NewChop function initializes a new CHOP instance with the default parameters.
-func NewChop[T helper.Number]() *Chop[T] {
+func NewChop[T helper.Float]() *Chop[T] {
 	return NewChopWithPeriod[T](DefaultChopPeriod)
 }
 
 // NewChopWithPeriod function initializes a new CHOP instance with the given period.
-func NewChopWithPeriod[T helper.Number](period int) *Chop[T] {
+func NewChopWithPeriod[T helper.Float](period int) *Chop[T] {
 	return &Chop[T]{
 		Period: period,
 	}

--- a/volatility/percent_b.go
+++ b/volatility/percent_b.go
@@ -15,18 +15,18 @@ import (
 // PercentB represents the parameters for calculating the %B indicator.
 //
 //	%B = (Close - Lower Band) / (Upper Band - Lower Band)
-type PercentB[T helper.Number] struct {
+type PercentB[T helper.Float] struct {
 	// BollingerBands is the underlying Bollinger Bands indicator used for calculations.
 	BollingerBands *BollingerBands[T]
 }
 
 // NewPercentB function initializes a new %B instance with the default parameters.
-func NewPercentB[T helper.Number]() *PercentB[T] {
+func NewPercentB[T helper.Float]() *PercentB[T] {
 	return NewPercentBWithPeriod[T](DefaultBollingerBandsPeriod)
 }
 
 // NewPercentBWithPeriod function initializes a new %B instance with the given period.
-func NewPercentBWithPeriod[T helper.Number](period int) *PercentB[T] {
+func NewPercentBWithPeriod[T helper.Float](period int) *PercentB[T] {
 	return &PercentB[T]{
 		BollingerBands: NewBollingerBandsWithPeriod[T](period),
 	}

--- a/volatility/po.go
+++ b/volatility/po.go
@@ -28,7 +28,7 @@ const (
 //
 //	po := volatility.NewPo()
 //	ps := po.Compute(highs, lows, closings)
-type Po[T helper.Number] struct {
+type Po[T helper.Float] struct {
 	// Mls is the Moving Least Square instance.
 	mls *trend.Mls[T]
 
@@ -40,12 +40,12 @@ type Po[T helper.Number] struct {
 }
 
 // NewPo function initializes a new PO instance with the default parameters.
-func NewPo[T helper.Number]() *Po[T] {
+func NewPo[T helper.Float]() *Po[T] {
 	return NewPoWithPeriod[T](DefaultPoPeriod)
 }
 
 // NewPoWithPeriod function initializes a new PO instance with the given period.
-func NewPoWithPeriod[T helper.Number](period int) *Po[T] {
+func NewPoWithPeriod[T helper.Float](period int) *Po[T] {
 	return &Po[T]{
 		mls: trend.NewMlsWithPeriod[T](period),
 		min: trend.NewMovingMinWithPeriod[T](period),

--- a/volatility/z_score.go
+++ b/volatility/z_score.go
@@ -26,18 +26,18 @@ const (
 //
 //	z := NewZScore[float64]()
 //	z.Compute(c)
-type ZScore[T helper.Number] struct {
+type ZScore[T helper.Float] struct {
 	// Period is the time period.
 	Period int
 }
 
 // NewZScore function initializes a new Z-Score instance with default parameters.
-func NewZScore[T helper.Number]() *ZScore[T] {
+func NewZScore[T helper.Float]() *ZScore[T] {
 	return NewZScoreWithPeriod[T](DefaultZScorePeriod)
 }
 
 // NewZScoreWithPeriod function initializes a new Z-Score instance with the given period.
-func NewZScoreWithPeriod[T helper.Number](period int) *ZScore[T] {
+func NewZScoreWithPeriod[T helper.Float](period int) *ZScore[T] {
 	return &ZScore[T]{
 		Period: period,
 	}

--- a/volume/ad.go
+++ b/volume/ad.go
@@ -21,13 +21,13 @@ import (
 //
 //	ad := volume.NewAd[float64]()
 //	result := ad.Compute(highs, lows, closings, volumes)
-type Ad[T helper.Number] struct {
+type Ad[T helper.Float] struct {
 	// Mfv is the MFV instance.
 	Mfv *Mfv[T]
 }
 
 // NewAd function initializes a new A/D instance with the default parameters.
-func NewAd[T helper.Number]() *Ad[T] {
+func NewAd[T helper.Float]() *Ad[T] {
 	return &Ad[T]{
 		Mfv: NewMfv[T](),
 	}

--- a/volume/cmf.go
+++ b/volume/cmf.go
@@ -28,7 +28,7 @@ const (
 //
 //	cmf := volume.NewCmf[float64]()
 //	result := cmf.Compute(highs, lows, closings, volumes)
-type Cmf[T helper.Number] struct {
+type Cmf[T helper.Float] struct {
 	// Mfv is the MFV instance.
 	Mfv *Mfv[T]
 
@@ -37,12 +37,12 @@ type Cmf[T helper.Number] struct {
 }
 
 // NewCmf function initializes a new CMF instance with the default parameters.
-func NewCmf[T helper.Number]() *Cmf[T] {
+func NewCmf[T helper.Float]() *Cmf[T] {
 	return NewCmfWithPeriod[T](DefaultCmfPeriod)
 }
 
 // NewCmfWithPeriod function initializes a new CMF instance with the given period.
-func NewCmfWithPeriod[T helper.Number](period int) *Cmf[T] {
+func NewCmfWithPeriod[T helper.Float](period int) *Cmf[T] {
 	return &Cmf[T]{
 		Mfv: NewMfv[T](),
 		Sum: trend.NewMovingSumWithPeriod[T](period),

--- a/volume/mfm.go
+++ b/volume/mfm.go
@@ -24,10 +24,10 @@ import (
 //
 //	mfm := volume.NewMfm[float64]()
 //	result := mfm.Compute(highs, lows, closings)
-type Mfm[T helper.Number] struct{}
+type Mfm[T helper.Float] struct{}
 
 // NewMfm function initializes a new MFM instance with the default parameters.
-func NewMfm[T helper.Number]() *Mfm[T] {
+func NewMfm[T helper.Float]() *Mfm[T] {
 	return &Mfm[T]{}
 }
 

--- a/volume/mfv.go
+++ b/volume/mfv.go
@@ -22,13 +22,13 @@ import (
 //
 //	mfv := volume.NewMfv[float64]()
 //	result := mfv.Compute(highs, lows, closings, volumes)
-type Mfv[T helper.Number] struct {
+type Mfv[T helper.Float] struct {
 	// Mfm is the MFM instance.
 	Mfm *Mfm[T]
 }
 
 // NewMfv function initializes a new MFV instance with the default parameters.
-func NewMfv[T helper.Number]() *Mfv[T] {
+func NewMfv[T helper.Float]() *Mfv[T] {
 	return &Mfv[T]{
 		Mfm: NewMfm[T](),
 	}

--- a/volume/vwap.go
+++ b/volume/vwap.go
@@ -26,18 +26,18 @@ const (
 //
 //	vwap := volume.NewVwap[float64]()
 //	result := vwap.Compute(closings, volumes)
-type Vwap[T helper.Number] struct {
+type Vwap[T helper.Float] struct {
 	// Sum is the Moving Sum instance.
 	Sum *trend.MovingSum[T]
 }
 
 // NewVwap function initializes a new VWAP instance with the default parameters.
-func NewVwap[T helper.Number]() *Vwap[T] {
+func NewVwap[T helper.Float]() *Vwap[T] {
 	return NewVwapWithPeriod[T](DefaultVwapPeriod)
 }
 
 // NewVwapWithPeriod function initializes a new VWAP instance with the given period.
-func NewVwapWithPeriod[T helper.Number](period int) *Vwap[T] {
+func NewVwapWithPeriod[T helper.Float](period int) *Vwap[T] {
 	return &Vwap[T]{
 		Sum: trend.NewMovingSumWithPeriod[T](period),
 	}


### PR DESCRIPTION
## Summary
- Same mechanical class of fix as #459 (EMA/RMA/SMMA) and #442 (Cci): a systematic classification pass identified 19 leaf indicator types whose formulas divide by a quantity that can legitimately be zero on real data (`high-low` on a flat bar, a moving sum of volume with no trading, a standard deviation of a flat window, etc.). Under `[T helper.Number]`, an integer `T` silently truncates that division to `0` instead of erroring, which is a distinct bug from the underlying float64 zero-denominator exposure (see follow-up list below, intentionally NOT addressed here).
- Constrains those 19 types from `[T helper.Number]` to `[T helper.Float]` (struct + all `NewX`/`NewXWithPeriod` constructors), then follows the build-driven fixpoint used in #459: run `go build ./...`, tighten whatever it reports, repeat until clean.
- `helper.Float` (`float32 | float64`) is a strict subset of `helper.Number`, and every in-tree caller already instantiates these with `float64`, so this is non-breaking for all in-tree code. It is technically a breaking API change for a hypothetical external caller instantiating one of these generics with an integer type (none exist in-tree).
- Purely mechanical / zero behavior change: no NaN/Inf guards, fallback values, or other runtime behavior were added or changed.

### Types touched — original 19 (independently high-risk)
`Bop`, `Kama`, `Kdj`, `Vwma`, `Cfo`, `SlowStochastic`, `Stochastic`, `StochasticOscillator`, `UltimateOscillator`, `InternalBarStrength`, `AccelerationBands`, `BollingerBandWidth`, `Po`, `PercentB`, `Chop`, `ZScore`, `Mfm`, `Cmf`, `Vwap`.

`Tsi` was on the original risk list but needed **no change**: its `NewTsi`/`NewTsiWith` constructors were already tightened to `helper.Float` by #459 (the `Tsi` struct itself only holds `Ma[T]` interface fields, so it stays `[T helper.Number]`, matching the `Envelope` precedent from #459).

### Forced dependents (pulled in by the build, not independently chosen)
- `Mfv` — constructs the now-`Float`-only `Mfm`.
- `Ad` — constructs the now-`Float`-only `Mfv`.

### Explicitly left untouched
The 13 types classified as integer-truncation-only with no live float64 risk (`Aroon`, `Mlr`, `Mls`, `Slope`, `Sma`, `Wma`, `Hma`, `Trima`, `TypicalPrice`, `WeightedClose`, `Envelope`, `AwesomeOscillator`, `IchimokuCloud`, `DonchianChannel`, `MovingStd`, `SuperTrend`) were not forced to change by the build and remain `[T helper.Number]`. Also confirmed: `WilliamsR` was already `[T helper.Float]` before this PR (untouched); `Sma`, `MovingSum`, `MovingMax`, `MovingMin`, `Mlr`, `Mls`, `BollingerBands`, `MovingStd`, `Atr` all stay `[T helper.Number]` since nothing forces them — a stricter (`Float`) type argument still trivially satisfies a looser (`Number`) constraint on the types they construct.

## Follow-up: live float64 divide-by-zero/NaN/Inf exposure (NOT fixed here, separately scoped)
This PR only fixes integer truncation. Every item below still has a live float64 zero-denominator exposure after this PR and would need its own per-indicator judgment call (e.g. the `momentum/rsi.go` flat-market fix) in a future PR:

- **Bop**: divides by `(high - low)`; flat bar → NaN/Inf.
- **Kama**: divides by a moving sum of `Abs(change)`; flat window → NaN/Inf (SC).
- **Kdj**: divides by `(Max(High) - Min(Low))`; flat range → NaN/Inf (RSV).
- **Tsi**: divides by `apcds` (EMA of `Abs(change)`); flat market → NaN/Inf.
- **Vwma**: divides by a moving sum of volume; no trading → NaN/Inf.
- **Cfo**: divides by the raw closing price; a zero/negative price input → NaN/Inf (edge case, not typical for equities).
- **SlowStochastic** / **Stochastic**: divide by `(Max - Min)`; flat range → NaN/Inf.
- **StochasticOscillator**: divides by `(Max - Min)`; flat range → NaN/Inf.
- **UltimateOscillator**: divides a buying-pressure sum by a true-range sum; flat market → NaN/Inf.
- **InternalBarStrength**: already guarded — has an explicit `denom == 0` check returning `0`, so this one is already fully safe for float64. No follow-up needed.
- **AccelerationBands**: divides by `(highs - lows)` (as `(High+Low)` denominator inside the band-width ratio, per the formula) — flat/degenerate input → NaN/Inf.
- **BollingerBandWidth**: divides by the middle band value; a zero-price middle band → NaN/Inf (edge case).
- **Po**: divides by `(PH - PL)`; flat range → NaN/Inf.
- **PercentB**: divides by `(upperBand - lowerBand)`; flat market → NaN/Inf.
- **Chop**: has its own `diff == 0` guard already (returns `0`) — already safe for float64.
- **ZScore**: divides by standard deviation; flat window (std = 0) → NaN/Inf.
- **Mfm**: divides by `(high - low)`; flat bar → NaN/Inf. (Propagates into `Mfv`, `Ad`, `Cmf` via their `helper.DivideWithContext`/multiply chains where applicable.)
- **Cmf**: divides a sum of money-flow-volume by a sum of volume; no trading → NaN/Inf.
- **Vwap**: divides by a sum of volume; no trading → NaN/Inf.

(While reading these files I also noticed `Chop` already has a `diff == 0` guard, matching `InternalBarStrength`'s pattern — both already fully float64-safe, correcting one item from the original triage list.)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean on all touched files (pre-existing unrelated gofmt drift in unrelated example/test files, untouched by this PR)
- [x] `go test ./...` passes with zero fixture changes

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp