### PR TITLE
Add zero-denominator guards to Mfm/Cmf/Vwap

### DIFF
--- a/volume/cmf.go
+++ b/volume/cmf.go
@@ -24,6 +24,11 @@ const (
 //	MFV = MFM * Volume
 //	CMF = Sum(20, Money Flow Volume) / Sum(20, Volume)
 //
+// When no trading occurred anywhere in the window, the volume sum is 0 and the
+// money-flow-volume-weighted ratio is undefined (0/0). CMF returns 0, since a
+// value near 0 conventionally reads as "no strong buying or selling pressure" -
+// exactly what a window with no trading should report.
+//
 // Example:
 //
 //	cmf := volume.NewCmf[float64]()
@@ -58,8 +63,15 @@ func (c *Cmf[T]) ComputeWithContext(ctx context.Context, highs, lows, closings, 
 	mfvs := c.Mfv.ComputeWithContext(ctx, highs, lows, closings, volumesSplice[0])
 
 	//	CMF = Sum(20, Money Flow Volume) / Sum(20, Volume)
-	return helper.DivideWithContext(ctx, c.Sum.ComputeWithContext(ctx, mfvs),
+	return helper.OperateWithContext(ctx, c.Sum.ComputeWithContext(ctx, mfvs),
 		c.Sum.ComputeWithContext(ctx, volumesSplice[1]),
+		func(mfvSum, volumeSum T) T {
+			if volumeSum == 0 {
+				return 0
+			}
+
+			return mfvSum / volumeSum
+		},
 	)
 }
 

--- a/volume/cmf_test.go
+++ b/volume/cmf_test.go
@@ -42,6 +42,22 @@ func TestCmf(t *testing.T) {
 	}
 }
 
+func TestCmfZeroVolume(t *testing.T) {
+	highs := helper.SliceToChan([]float64{11, 11, 11, 11})
+	lows := helper.SliceToChan([]float64{9, 9, 9, 9})
+	closings := helper.SliceToChan([]float64{10, 10, 10, 10})
+	volumes := helper.SliceToChan([]float64{0, 0, 0, 0})
+
+	cmf := volume.NewCmfWithPeriod[float64](2)
+	actuals := cmf.Compute(highs, lows, closings, volumes)
+
+	for actual := range actuals {
+		if actual != 0 {
+			t.Fatalf("expected 0 when window volume is 0, got %v", actual)
+		}
+	}
+}
+
 func TestCmfString(t *testing.T) {
 	expected := "CMF(20)"
 	actual := volume.NewCmf[float64]().String()

--- a/volume/mfm.go
+++ b/volume/mfm.go
@@ -20,6 +20,12 @@ import (
 // - MFM of 1: Close equals high, strongest buying pressure.
 // - MFM of -1: Close equals low, strongest selling pressure.
 //
+// On a flat bar (High == Low), the close's position within the range is undefined
+// (0/0). MFM returns 0, the neutral point of its [-1, 1] scale, matching the
+// InternalBarStrength precedent for the identical High-Low denominator. Since MFM
+// feeds Mfv, Ad, and Cmf, a neutral 0 flows through as "zero contribution" to all
+// of them.
+//
 // Example:
 //
 //	mfm := volume.NewMfm[float64]()
@@ -33,15 +39,14 @@ func NewMfm[T helper.Float]() *Mfm[T] {
 
 // ComputeWithContext function takes a channel of numbers and computes the MFM.
 func (i *Mfm[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-chan T) <-chan T {
-	highsSplice := helper.DuplicateWithContext(ctx, highs, 2)
-	lowsSplice := helper.DuplicateWithContext(ctx, lows, 2)
-	closingsSplice := helper.DuplicateWithContext(ctx, closings, 2)
+	return helper.Operate3WithContext(ctx, highs, lows, closings, func(high, low, closing T) T {
+		denom := high - low
+		if denom == 0 {
+			return 0
+		}
 
-	return helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, helper.SubtractWithContext(ctx, closingsSplice[0], lowsSplice[0]),
-		helper.SubtractWithContext(ctx, highsSplice[0], closingsSplice[1]),
-	),
-		helper.SubtractWithContext(ctx, highsSplice[1], lowsSplice[1]),
-	)
+		return ((closing - low) - (high - closing)) / denom
+	})
 }
 
 // IdlePeriod is the initial period that MFM won't yield any results.

--- a/volume/mfm_test.go
+++ b/volume/mfm_test.go
@@ -40,6 +40,21 @@ func TestMfm(t *testing.T) {
 	}
 }
 
+func TestMfmZeroDenom(t *testing.T) {
+	highs := helper.SliceToChan([]float64{10, 10, 10})
+	lows := helper.SliceToChan([]float64{10, 10, 10})
+	closings := helper.SliceToChan([]float64{10, 10, 10})
+
+	mfm := volume.NewMfm[float64]()
+	actuals := mfm.Compute(highs, lows, closings)
+
+	for actual := range actuals {
+		if actual != 0 {
+			t.Fatalf("expected 0 when high == low, got %v", actual)
+		}
+	}
+}
+
 func TestMfmString(t *testing.T) {
 	expected := "MFM"
 	actual := volume.NewMfm[float64]().String()

--- a/volume/vwap.go
+++ b/volume/vwap.go
@@ -22,6 +22,17 @@ const (
 //
 //	VWAP = Sum(Closing * Volume) / Sum(Volume)
 //
+// When no trading occurred anywhere in the window, the volume sum is 0 and a
+// volume-weighted price is undefined (0/0). Unlike MFM/CMF, 0 is not a safe
+// stand-in here: a VWAP of 0 would read as a real, implausibly low price rather
+// than "no data," which is actively misleading if plotted or compared against
+// actual prices (see the example WeightedAveragePriceStrategy, which crosses
+// closing price against VWAP - a fabricated 0 would falsely signal a crossover
+// every time). Instead, VWAP carries forward the last period with actual volume,
+// which is the conventional real-market handling for an illiquid bar. Before any
+// window has had volume, there is no prior value to carry forward, so VWAP
+// returns the zero value of T.
+//
 // Example:
 //
 //	vwap := volume.NewVwap[float64]()
@@ -47,12 +58,25 @@ func NewVwapWithPeriod[T helper.Float](period int) *Vwap[T] {
 func (v *Vwap[T]) ComputeWithContext(ctx context.Context, closings, volumes <-chan T) <-chan T {
 	volumesSplice := helper.DuplicateWithContext(ctx, volumes, 2)
 
-	return helper.DivideWithContext(ctx, v.Sum.ComputeWithContext(ctx, helper.MultiplyWithContext(ctx, closings,
+	sumPriceVolume := v.Sum.ComputeWithContext(ctx, helper.MultiplyWithContext(ctx, closings,
 		volumesSplice[0],
-	),
-	),
-		v.Sum.ComputeWithContext(ctx, volumesSplice[1]),
-	)
+	))
+	sumVolume := v.Sum.ComputeWithContext(ctx, volumesSplice[1])
+
+	// last holds the most recently computed valid VWAP, carried forward when a
+	// window has no volume. OperateWithContext runs sequentially, so this
+	// closure state is safe without synchronization.
+	var last T
+
+	return helper.OperateWithContext(ctx, sumPriceVolume, sumVolume, func(priceVolumeSum, volumeSum T) T {
+		if volumeSum == 0 {
+			return last
+		}
+
+		last = priceVolumeSum / volumeSum
+
+		return last
+	})
 }
 
 // IdlePeriod is the initial period that VWAP won't yield any results.

--- a/volume/vwap_test.go
+++ b/volume/vwap_test.go
@@ -38,6 +38,42 @@ func TestVwap(t *testing.T) {
 	}
 }
 
+func TestVwapZeroVolume(t *testing.T) {
+	closings := helper.SliceToChan([]float64{10, 20, 30})
+	volumes := helper.SliceToChan([]float64{0, 0, 0})
+
+	vwap := volume.NewVwapWithPeriod[float64](2)
+	actuals := vwap.Compute(closings, volumes)
+
+	for actual := range actuals {
+		if actual != 0 {
+			t.Fatalf("expected 0 before any window has volume, got %v", actual)
+		}
+	}
+}
+
+func TestVwapCarriesForwardOnZeroVolume(t *testing.T) {
+	closings := helper.SliceToChan([]float64{10, 20, 30, 40})
+	volumes := helper.SliceToChan([]float64{5, 5, 0, 0})
+
+	vwap := volume.NewVwapWithPeriod[float64](2)
+	actuals := helper.ChanToSlice(vwap.Compute(closings, volumes))
+
+	// Windows: (10,20)@vol(5,5) -> 15; (20,30)@vol(5,0) -> 20;
+	// (30,40)@vol(0,0) -> carries forward the last valid VWAP, 20.
+	expected := []float64{15, 20, 20}
+
+	if len(actuals) != len(expected) {
+		t.Fatalf("expected %d values but got %d", len(expected), len(actuals))
+	}
+
+	for i, actual := range actuals {
+		if actual != expected[i] {
+			t.Fatalf("index %d: expected %v but got %v", i, expected[i], actual)
+		}
+	}
+}
+
 func TestVwapString(t *testing.T) {
 	expected := "VWAP(14)"
 	actual := volume.NewVwap[float64]().String()


### PR DESCRIPTION
## Summary
- Follow-up to #496 ("Tighten high-risk indicators to helper.Float"), which fixed the integer-truncation gap for these types but explicitly left zero-denominator behavior unaddressed. This PR adds the guards for the `volume/` trio flagged in the audit: `Mfm`, `Cmf`, `Vwap`.
- `Mfm` (Money Flow Multiplier, `((Close-Low)-(High-Close))/(High-Low)`): on a flat bar (`High == Low`) the ratio is 0/0. Returns **0**, the neutral midpoint of its `[-1, 1]` scale — the same fallback already used in this codebase for the identical `(High-Low)` denominator shape in `momentum/ibs.go` (Internal Bar Strength). Since `Mfm` feeds `Mfv`, `Ad`, and `Cmf`, a neutral 0 propagates as "zero contribution" to all of them, which is the sensible degenerate case.
- `Cmf` (Chaikin Money Flow, moving-sum(MFV)/moving-sum(Volume)): when no trading occurred anywhere in the window, the volume sum is 0. Returns **0** — CMF near 0 is conventionally read as "no strong buying or selling pressure," which is exactly the right signal for "no trading happened."
- `Vwap` (Volume Weighted Average Price, moving-sum(Close*Volume)/moving-sum(Volume)): this is the one case where 0 is *not* a safe fallback. Unlike Mfm/Cmf, which have a signed scale where 0 means "neutral," VWAP is a price. A VWAP of 0 would look like a real (absurdly low) traded price rather than "no data," and the in-tree `WeightedAveragePriceStrategy` example crosses closing price against VWAP — a fabricated 0 would falsely fire a crossover signal on every illiquid bar. Instead, `Vwap` now **carries the last valid VWAP forward** across a zero-volume window (the conventional handling for an illiquid bar in real market data/feeds), and returns the zero value of `T` only before any window has ever had volume (nothing valid exists yet to carry forward).
- Style follows the existing `denom == 0` guard pattern from `momentum/ibs.go` / `volatility/chop.go`. `Mfm` was refactored from a `Subtract`/`Divide` helper-chain to a single `Operate3WithContext` closure (matching `ibs.go` exactly) so the guard reads the same way; `Cmf`/`Vwap` use `OperateWithContext` in place of `DivideWithContext` for the same reason (Vwap's closure additionally holds the last-valid value in captured state, safe because `OperateWithContext` runs sequentially).
- Each type's doc comment documents its chosen fallback and reasoning.

## Test plan
- [x] Added `TestMfmZeroDenom`: flat `High==Low==Close` input, confirms `Mfm` returns 0 instead of NaN.
- [x] Added `TestCmfZeroVolume`: non-flat prices with all-zero volume over the window, confirms `Cmf` returns 0 instead of NaN.
- [x] Added `TestVwapZeroVolume`: all-zero volume from the start, confirms `Vwap` returns 0 (nothing to carry forward yet).
- [x] Added `TestVwapCarriesForwardOnZeroVolume`: volume present then drops to 0, confirms `Vwap` holds the last valid value (15, 20, 20) instead of dropping to 0/NaN.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (touched files clean; pre-existing unrelated formatting diffs elsewhere untouched), `go test ./...` all pass.
- [x] Verified `volume/testdata/{mfm,cmf,vwap}.csv` contain no flat-range or zero-volume rows, so existing fixture-based tests are unaffected by the new guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp