### PR TITLE
Tighten remaining low-risk indicators to helper.Float

### DIFF
--- a/momentum/awesome_oscillator.go
+++ b/momentum/awesome_oscillator.go
@@ -33,7 +33,7 @@ const (
 //
 //	ao := momentum.NewAwesomeOscillator[float64]()
 //	values := ao.Compute(lows, highs)
-type AwesomeOscillator[T helper.Number] struct {
+type AwesomeOscillator[T helper.Float] struct {
 	// ShortSma is the SMA for the short period.
 	ShortSma *trend.Sma[T]
 
@@ -42,7 +42,7 @@ type AwesomeOscillator[T helper.Number] struct {
 }
 
 // NewAwesomeOscillator function initializes a new Awesome Oscillator instance.
-func NewAwesomeOscillator[T helper.Number]() *AwesomeOscillator[T] {
+func NewAwesomeOscillator[T helper.Float]() *AwesomeOscillator[T] {
 	return &AwesomeOscillator[T]{
 		ShortSma: trend.NewSmaWithPeriod[T](DefaultAwesomeOscillatorShortPeriod),
 		LongSma:  trend.NewSmaWithPeriod[T](DefaultAwesomeOscillatorLongPeriod),

--- a/momentum/ichimoku_cloud.go
+++ b/momentum/ichimoku_cloud.go
@@ -45,7 +45,7 @@ const (
 //
 //	ic := momentum.NewIchimokuCloud[float64]()
 //	conversionLine, baseLine, leadingSpanA, leasingSpanB, laggingSpan := ic.Compute(highs, lows, closings)
-type IchimokuCloud[T helper.Number] struct {
+type IchimokuCloud[T helper.Float] struct {
 	// ConversionMax is the conversion Moving Max instance.
 	ConversionMax *trend.MovingMax[T]
 
@@ -69,7 +69,7 @@ type IchimokuCloud[T helper.Number] struct {
 }
 
 // NewIchimokuCloud function initializes a new Ichimoku Cloud instance.
-func NewIchimokuCloud[T helper.Number]() *IchimokuCloud[T] {
+func NewIchimokuCloud[T helper.Float]() *IchimokuCloud[T] {
 	return &IchimokuCloud[T]{
 		ConversionMax: trend.NewMovingMaxWithPeriod[T](DefaultIchimokuCloudConversionPeriod),
 		ConversionMin: trend.NewMovingMinWithPeriod[T](DefaultIchimokuCloudConversionPeriod),

--- a/momentum/qstick.go
+++ b/momentum/qstick.go
@@ -33,12 +33,12 @@ const (
 //	qstick.Sma.Period = 50
 //
 //	values := qstick.Compute(openings, closings)
-type Qstick[T helper.Number] struct {
+type Qstick[T helper.Float] struct {
 	Sma *trend.Sma[T]
 }
 
 // NewQstick function initializes a new QStick instance.
-func NewQstick[T helper.Number]() *Qstick[T] {
+func NewQstick[T helper.Float]() *Qstick[T] {
 	qstick := &Qstick[T]{
 		Sma: trend.NewSma[T](),
 	}

--- a/trend/aroon.go
+++ b/trend/aroon.go
@@ -32,14 +32,14 @@ const (
 //	aroon.Period = 25
 //
 //	result := aroon.Compute(c)
-type Aroon[T helper.Number] struct {
+type Aroon[T helper.Float] struct {
 	// Period is the period to use.
 	Period int
 }
 
 // NewAroon function initializes a new Aroon instance
 // with the default parameters.
-func NewAroon[T helper.Number]() *Aroon[T] {
+func NewAroon[T helper.Float]() *Aroon[T] {
 	return &Aroon[T]{
 		Period: DefaultAroonPeriod,
 	}

--- a/trend/envelope.go
+++ b/trend/envelope.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Envelope represents the parameters neededd to calcualte the Envelope.
-type Envelope[T helper.Number] struct {
+type Envelope[T helper.Float] struct {
 	// Ma is the moving average used.
 	Ma Ma[T]
 
@@ -30,7 +30,7 @@ type Envelope[T helper.Number] struct {
 }
 
 // NewEnvelope function initializes a new Envelope instance with the default parameters.
-func NewEnvelope[T helper.Number](ma Ma[T], percentage T) *Envelope[T] {
+func NewEnvelope[T helper.Float](ma Ma[T], percentage T) *Envelope[T] {
 	return &Envelope[T]{
 		Ma:         ma,
 		Percentage: percentage,
@@ -38,7 +38,7 @@ func NewEnvelope[T helper.Number](ma Ma[T], percentage T) *Envelope[T] {
 }
 
 // NewEnvelopeWithSma function initalizes a new Envelope instance using SMA.
-func NewEnvelopeWithSma[T helper.Number]() *Envelope[T] {
+func NewEnvelopeWithSma[T helper.Float]() *Envelope[T] {
 	return NewEnvelope(
 		NewSmaWithPeriod[T](DefaultEnvelopePeriod),
 		T(DefaultEnvelopePercentage),

--- a/trend/hma.go
+++ b/trend/hma.go
@@ -33,7 +33,7 @@ const (
 // periods this matches the common truncating variants, but for odd periods it can yield a WMA1 length
 // one greater than a truncating implementation would use, which may explain small output differences
 // when cross-checking against another platform's HMA.
-type Hma[T helper.Number] struct {
+type Hma[T helper.Float] struct {
 	// First WMA.
 	wma1 *Wma[T]
 
@@ -45,12 +45,12 @@ type Hma[T helper.Number] struct {
 }
 
 // NewHma function initializes a new HMA instance with the default parameters.
-func NewHma[T helper.Number]() *Hma[T] {
+func NewHma[T helper.Float]() *Hma[T] {
 	return NewHmaWithPeriod[T](DefaultHmaPeriod)
 }
 
 // NewHmaWithPeriod function initializes a new HMA instance with the given parameters.
-func NewHmaWithPeriod[T helper.Number](period int) *Hma[T] {
+func NewHmaWithPeriod[T helper.Float](period int) *Hma[T] {
 	return &Hma[T]{
 		// Rounded rather than truncated; see the variant-choice note on the Hma type above.
 		wma1: NewWmaWithPeriod[T](int(math.Round(float64(period) / 2))),

--- a/trend/mlr.go
+++ b/trend/mlr.go
@@ -24,18 +24,18 @@ const (
 //
 //	mlr := trend.NewMlrWithPeriod[float64](14)
 //	rs := mlr.Compute(x , y)
-type Mlr[T helper.Number] struct {
+type Mlr[T helper.Float] struct {
 	// Mls is the Moving Least Square instance.
 	Mls *Mls[T]
 }
 
 // NewMlr function initializes a new MLR instance with the default parameters.
-func NewMlr[T helper.Number]() *Mlr[T] {
+func NewMlr[T helper.Float]() *Mlr[T] {
 	return NewMlrWithPeriod[T](DefaultMlrPeriod)
 }
 
 // NewMlrWithPeriod function initializes a new MLR instance with the given period.
-func NewMlrWithPeriod[T helper.Number](period int) *Mlr[T] {
+func NewMlrWithPeriod[T helper.Float](period int) *Mlr[T] {
 	return &Mlr[T]{
 		Mls: NewMlsWithPeriod[T](period),
 	}

--- a/trend/mls.go
+++ b/trend/mls.go
@@ -30,18 +30,18 @@ const (
 //
 //	mls := trend.NewMlsWithPeriod[float64](14)
 //	ms, bs := mls.Compute(x , y)
-type Mls[T helper.Number] struct {
+type Mls[T helper.Float] struct {
 	// Sum is the moving sum instance.
 	Sum *MovingSum[T]
 }
 
 // NewMls function initializes a new MLS instance with the default parameters.
-func NewMls[T helper.Number]() *Mls[T] {
+func NewMls[T helper.Float]() *Mls[T] {
 	return NewMlsWithPeriod[T](DefaultMlsPeriod)
 }
 
 // NewMlsWithPeriod function initializes a new MLS instance with the given period.
-func NewMlsWithPeriod[T helper.Number](period int) *Mls[T] {
+func NewMlsWithPeriod[T helper.Float](period int) *Mls[T] {
 	return &Mls[T]{
 		Sum: NewMovingSumWithPeriod[T](period),
 	}

--- a/trend/slope.go
+++ b/trend/slope.go
@@ -23,18 +23,18 @@ const (
 //	Slope = (Current Price - Price n periods ago) / n
 //
 // Refactored to utilize composition of helper.Change and helper.DivideBy.
-type Slope[T helper.Number] struct {
+type Slope[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewSlope function initializes a new Slope instance with the default parameters.
-func NewSlope[T helper.Number]() *Slope[T] {
+func NewSlope[T helper.Float]() *Slope[T] {
 	return NewSlopeWithPeriod[T](DefaultSlopePeriod)
 }
 
 // NewSlopeWithPeriod function initializes a new Slope instance with the given parameters.
-func NewSlopeWithPeriod[T helper.Number](period int) *Slope[T] {
+func NewSlopeWithPeriod[T helper.Float](period int) *Slope[T] {
 	if period <= 0 {
 		period = DefaultSlopePeriod
 	}

--- a/trend/sma.go
+++ b/trend/sma.go
@@ -25,18 +25,18 @@ const (
 //	sma.Period = 10
 //
 //	result := sma.Compute(c)
-type Sma[T helper.Number] struct {
+type Sma[T helper.Float] struct {
 	// Period is the time period for the SMA.
 	Period int
 }
 
 // NewSma function initializes a new SMA instance with the default parameters.
-func NewSma[T helper.Number]() *Sma[T] {
+func NewSma[T helper.Float]() *Sma[T] {
 	return NewSmaWithPeriod[T](DefaultSmaPeriod)
 }
 
 // NewSmaWithPeriod function initializes a new SMA instance with the default parameters.
-func NewSmaWithPeriod[T helper.Number](period int) *Sma[T] {
+func NewSmaWithPeriod[T helper.Float](period int) *Sma[T] {
 	return &Sma[T]{
 		Period: period,
 	}

--- a/trend/trima.go
+++ b/trend/trima.go
@@ -26,20 +26,20 @@ const (
 // If period is odd:
 //
 //	TRIMA = SMA((period + 1) / 2, SMA((period + 1) / 2, values))
-type Trima[T helper.Number] struct {
+type Trima[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewTrima function initializes a new TRIMA instance
 // with the default parameters.
-func NewTrima[T helper.Number]() *Trima[T] {
+func NewTrima[T helper.Float]() *Trima[T] {
 	return NewTrimaWithPeriod[T](DefaultTrimaPeriod)
 }
 
 // NewTrimaWithPeriod function initializes a new TRIMA instance
 // with the given period.
-func NewTrimaWithPeriod[T helper.Number](period int) *Trima[T] {
+func NewTrimaWithPeriod[T helper.Float](period int) *Trima[T] {
 	return &Trima[T]{
 		Period: period,
 	}

--- a/trend/typical_price.go
+++ b/trend/typical_price.go
@@ -15,10 +15,10 @@ import (
 // filter for moving average systems.
 //
 //	Typical Price = (High + Low + Closing) / 3
-type TypicalPrice[T helper.Number] struct{}
+type TypicalPrice[T helper.Float] struct{}
 
 // NewTypicalPrice function initializes a new Typical Price instance with the default parameters.
-func NewTypicalPrice[T helper.Number]() *TypicalPrice[T] {
+func NewTypicalPrice[T helper.Float]() *TypicalPrice[T] {
 	return &TypicalPrice[T]{}
 }
 

--- a/trend/weighted_close.go
+++ b/trend/weighted_close.go
@@ -18,11 +18,11 @@ import (
 //
 //	weightedClose := trend.NewWeightedClose[float64]()
 //	result := weightedClose.Compute(highs, lows, closes)
-type WeightedClose[T helper.Number] struct {
+type WeightedClose[T helper.Float] struct {
 }
 
 // NewWeightedClose function initializes a new Weighted Close instance with the default parameters.
-func NewWeightedClose[T helper.Number]() *WeightedClose[T] {
+func NewWeightedClose[T helper.Float]() *WeightedClose[T] {
 	return &WeightedClose[T]{}
 }
 

--- a/trend/wma.go
+++ b/trend/wma.go
@@ -21,18 +21,18 @@ const (
 // It calculates a moving average by putting more weight on recent data and less on past data.
 //
 //	WMA = (Oldest * 1 + ... + Newest * N) / (N * (N + 1) / 2)
-type Wma[T helper.Number] struct {
+type Wma[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewWma function initializes a new WMA instance with the default parameters.
-func NewWma[T helper.Number]() *Wma[T] {
+func NewWma[T helper.Float]() *Wma[T] {
 	return NewWmaWithPeriod[T](DefaultWmaPeriod)
 }
 
 // NewWmaWithPeriod function initializes a new WMA instance with the given parameters.
-func NewWmaWithPeriod[T helper.Number](period int) *Wma[T] {
+func NewWmaWithPeriod[T helper.Float](period int) *Wma[T] {
 	if period <= 0 {
 		panic("period must be greater than 0")
 	}
@@ -44,7 +44,7 @@ func NewWmaWithPeriod[T helper.Number](period int) *Wma[T] {
 // NewWmaWith is an alias for NewWmaWithPeriod for backwards compatibility.
 //
 // Deprecated: Use NewWmaWithPeriod instead.
-func NewWmaWith[T helper.Number](period int) *Wma[T] {
+func NewWmaWith[T helper.Float](period int) *Wma[T] {
 	return NewWmaWithPeriod[T](period)
 }
 

--- a/volatility/annualized_historical_volatility.go
+++ b/volatility/annualized_historical_volatility.go
@@ -27,7 +27,7 @@ const (
 // multiplying it by the square root of the number of trading days per year.
 //
 //	AHV = HV × √TradingDaysPerYear
-type AnnualizedHistoricalVolatility[T helper.Number] struct {
+type AnnualizedHistoricalVolatility[T helper.Float] struct {
 	// Hv is the underlying Historical Volatility indicator.
 	Hv *HistoricalVolatility[T]
 
@@ -37,13 +37,13 @@ type AnnualizedHistoricalVolatility[T helper.Number] struct {
 
 // NewAnnualizedHistoricalVolatility function initializes a new Annualized Historical Volatility
 // instance with the default parameters.
-func NewAnnualizedHistoricalVolatility[T helper.Number]() *AnnualizedHistoricalVolatility[T] {
+func NewAnnualizedHistoricalVolatility[T helper.Float]() *AnnualizedHistoricalVolatility[T] {
 	return NewAnnualizedHistoricalVolatilityWithPeriod[T](DefaultAnnualizedHistoricalVolatilityPeriod)
 }
 
 // NewAnnualizedHistoricalVolatilityWithPeriod function initializes a new Annualized Historical
 // Volatility instance with the given period.
-func NewAnnualizedHistoricalVolatilityWithPeriod[T helper.Number](period int) *AnnualizedHistoricalVolatility[T] {
+func NewAnnualizedHistoricalVolatilityWithPeriod[T helper.Float](period int) *AnnualizedHistoricalVolatility[T] {
 	return &AnnualizedHistoricalVolatility[T]{
 		Hv:                 NewHistoricalVolatilityWithPeriod[T](period),
 		TradingDaysPerYear: DefaultTradingDaysPerYear,

--- a/volatility/atr.go
+++ b/volatility/atr.go
@@ -30,23 +30,23 @@ const (
 //
 //	atr := volatility.NewAtr()
 //	atr.Compute(highs, lows, closings)
-type Atr[T helper.Number] struct {
+type Atr[T helper.Float] struct {
 	// Ma is the moving average for the ATR.
 	Ma trend.Ma[T]
 }
 
 // NewAtr function initializes a new ATR instance with the default parameters.
-func NewAtr[T helper.Number]() *Atr[T] {
+func NewAtr[T helper.Float]() *Atr[T] {
 	return NewAtrWithPeriod[T](DefaultAtrPeriod)
 }
 
 // NewAtrWithPeriod function initializes a new ATR instance with the given period.
-func NewAtrWithPeriod[T helper.Number](period int) *Atr[T] {
+func NewAtrWithPeriod[T helper.Float](period int) *Atr[T] {
 	return NewAtrWithMa(trend.NewSmaWithPeriod[T](period))
 }
 
 // NewAtrWithMa function initializes a new ATR instance with the given moving average instance.
-func NewAtrWithMa[T helper.Number](ma trend.Ma[T]) *Atr[T] {
+func NewAtrWithMa[T helper.Float](ma trend.Ma[T]) *Atr[T] {
 	return &Atr[T]{
 		Ma: ma,
 	}

--- a/volatility/bollinger_bands.go
+++ b/volatility/bollinger_bands.go
@@ -32,7 +32,7 @@ const (
 //
 //	bollingerBands := NewBollingerBands[float64]()
 //	bollingerBands.Compute(values)
-type BollingerBands[T helper.Number] struct {
+type BollingerBands[T helper.Float] struct {
 	// Time period.
 	Period int
 
@@ -41,12 +41,12 @@ type BollingerBands[T helper.Number] struct {
 }
 
 // NewBollingerBands function initializes a new Bollinger Bands instance with the default parameters.
-func NewBollingerBands[T helper.Number]() *BollingerBands[T] {
+func NewBollingerBands[T helper.Float]() *BollingerBands[T] {
 	return NewBollingerBandsWithPeriod[T](DefaultBollingerBandsPeriod)
 }
 
 // NewBollingerBandsWithPeriod function initializes a new Bollinger Bands instance with the given period.
-func NewBollingerBandsWithPeriod[T helper.Number](period int) *BollingerBands[T] {
+func NewBollingerBandsWithPeriod[T helper.Float](period int) *BollingerBands[T] {
 	return &BollingerBands[T]{
 		Period:     period,
 		Multiplier: DefaultBollingerBandsMultiplier,

--- a/volatility/chandelier_exit.go
+++ b/volatility/chandelier_exit.go
@@ -30,7 +30,7 @@ const (
 //
 //	ce := volatility.NewChandelierExit[float64]()
 //	ceLong, ceShort := ce.Compute(highs, lows, closings)
-type ChandelierExit[T helper.Number] struct {
+type ChandelierExit[T helper.Float] struct {
 	// Period is time period.
 	Period int
 
@@ -39,7 +39,7 @@ type ChandelierExit[T helper.Number] struct {
 }
 
 // NewChandelierExit function initializes a new Chandelier Exit instance with the default parameters.
-func NewChandelierExit[T helper.Number]() *ChandelierExit[T] {
+func NewChandelierExit[T helper.Float]() *ChandelierExit[T] {
 	return &ChandelierExit[T]{
 		Period:     DefaultChandelierExitPeriod,
 		Multiplier: DefaultChandelierExitMultiplier,

--- a/volatility/donchian_channel.go
+++ b/volatility/donchian_channel.go
@@ -30,7 +30,7 @@ const (
 //
 //	dc := volatility.NewDonchianChannel[float64]()
 //	uppers, middles, lowers := dc.Compute(highs, lows)
-type DonchianChannel[T helper.Number] struct {
+type DonchianChannel[T helper.Float] struct {
 	// Max is the Moving Max instance.
 	Max *trend.MovingMax[T]
 
@@ -39,12 +39,12 @@ type DonchianChannel[T helper.Number] struct {
 }
 
 // NewDonchianChannel function initializes a new Donchian Channel instance with the default parameters.
-func NewDonchianChannel[T helper.Number]() *DonchianChannel[T] {
+func NewDonchianChannel[T helper.Float]() *DonchianChannel[T] {
 	return NewDonchianChannelWithPeriod[T](DefaultDonchianChannelPeriod)
 }
 
 // NewDonchianChannelWithPeriod function initializes a new Donchian Channel instance with the given period.
-func NewDonchianChannelWithPeriod[T helper.Number](period int) *DonchianChannel[T] {
+func NewDonchianChannelWithPeriod[T helper.Float](period int) *DonchianChannel[T] {
 	return &DonchianChannel[T]{
 		Max: trend.NewMovingMaxWithPeriod[T](period),
 		Min: trend.NewMovingMinWithPeriod[T](period),

--- a/volatility/historical_volatility.go
+++ b/volatility/historical_volatility.go
@@ -23,18 +23,18 @@ const (
 //	where R_t = (P_t / P_(t-1)) - 1
 //
 // Refactored to utilize composition of helper.ChangeRatio and MovingStd.
-type HistoricalVolatility[T helper.Number] struct {
+type HistoricalVolatility[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewHistoricalVolatility function initializes a new Historical Volatility instance with the default parameters.
-func NewHistoricalVolatility[T helper.Number]() *HistoricalVolatility[T] {
+func NewHistoricalVolatility[T helper.Float]() *HistoricalVolatility[T] {
 	return NewHistoricalVolatilityWithPeriod[T](DefaultHistoricalVolatilityPeriod)
 }
 
 // NewHistoricalVolatilityWithPeriod function initializes a new Historical Volatility instance with the given period.
-func NewHistoricalVolatilityWithPeriod[T helper.Number](period int) *HistoricalVolatility[T] {
+func NewHistoricalVolatilityWithPeriod[T helper.Float](period int) *HistoricalVolatility[T] {
 	if period <= 0 {
 		period = DefaultHistoricalVolatilityPeriod
 	}

--- a/volatility/moving_std.go
+++ b/volatility/moving_std.go
@@ -22,18 +22,18 @@ const (
 // over the specified period.
 //
 //	Std = Sqrt(1/Period * Sum(Pow(value - sma), 2))
-type MovingStd[T helper.Number] struct {
+type MovingStd[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewMovingStd function initializes a new Moving Standard Deviation instance with the default parameters.
-func NewMovingStd[T helper.Number]() *MovingStd[T] {
+func NewMovingStd[T helper.Float]() *MovingStd[T] {
 	return NewMovingStdWithPeriod[T](DefaultMovingStdPeriod)
 }
 
 // NewMovingStdWithPeriod function initializes a new Moving Standard Deviation instance with the given period.
-func NewMovingStdWithPeriod[T helper.Number](period int) *MovingStd[T] {
+func NewMovingStdWithPeriod[T helper.Float](period int) *MovingStd[T] {
 	return &MovingStd[T]{
 		Period: period,
 	}

--- a/volatility/super_trend.go
+++ b/volatility/super_trend.go
@@ -44,13 +44,13 @@ const (
 // period. Use NewSuperTrendWithMa to use a different moving average, such as SMA or RMA.
 //
 // Example:
-type SuperTrend[T helper.Number] struct {
+type SuperTrend[T helper.Float] struct {
 	Atr        *Atr[T]
 	Multiplier T
 }
 
 // NewSuperTrend function initializes a new Super Trend instance with the default parameters.
-func NewSuperTrend[T helper.Number]() *SuperTrend[T] {
+func NewSuperTrend[T helper.Float]() *SuperTrend[T] {
 	multiplier := DefaultSuperTrendMultiplier
 
 	return NewSuperTrendWithPeriod[T](
@@ -64,7 +64,7 @@ func NewSuperTrend[T helper.Number]() *SuperTrend[T] {
 // The ATR used internally is built with HMA smoothing (not the textbook SMA/RMA), which increases
 // the effective idle period, e.g. 17 rather than 14 for the default period of 14. Use
 // NewSuperTrendWithMa directly if a different moving average, such as SMA or RMA, is desired.
-func NewSuperTrendWithPeriod[T helper.Number](period int, multiplier T) *SuperTrend[T] {
+func NewSuperTrendWithPeriod[T helper.Float](period int, multiplier T) *SuperTrend[T] {
 	return NewSuperTrendWithMa[T](
 		trend.NewHmaWithPeriod[T](period),
 		multiplier,
@@ -73,7 +73,7 @@ func NewSuperTrendWithPeriod[T helper.Number](period int, multiplier T) *SuperTr
 
 // NewSuperTrendWithMa function initializes a new Super Trend instance with the given moving average instance
 // and multiplier.
-func NewSuperTrendWithMa[T helper.Number](ma trend.Ma[T], multiplier T) *SuperTrend[T] {
+func NewSuperTrendWithMa[T helper.Float](ma trend.Ma[T], multiplier T) *SuperTrend[T] {
 	return &SuperTrend[T]{
 		Atr:        NewAtrWithMa(ma),
 		Multiplier: multiplier,

--- a/volatility/ulcer_index.go
+++ b/volatility/ulcer_index.go
@@ -30,13 +30,13 @@ const (
 //
 //	ui := volatility.NewUlcerIndex[float64]()
 //	ui.Compute(closings)
-type UlcerIndex[T helper.Number] struct {
+type UlcerIndex[T helper.Float] struct {
 	// Time period.
 	Period int
 }
 
 // NewUlcerIndex function initializes a new Ulcer Index instance with the default parameters.
-func NewUlcerIndex[T helper.Number]() *UlcerIndex[T] {
+func NewUlcerIndex[T helper.Float]() *UlcerIndex[T] {
 	return &UlcerIndex[T]{
 		Period: DefaultUlcerIndexPeriod,
 	}

--- a/volume/emv.go
+++ b/volume/emv.go
@@ -29,18 +29,18 @@ const (
 //
 //	emv := volume.NewEmv[float64]()
 //	result := emv.Compute(highs, lows, volumes)
-type Emv[T helper.Number] struct {
+type Emv[T helper.Float] struct {
 	// Sma is the SMA instance.
 	Sma *trend.Sma[T]
 }
 
 // NewEmv function initializes a new EMV instance with the default parameters.
-func NewEmv[T helper.Number]() *Emv[T] {
+func NewEmv[T helper.Float]() *Emv[T] {
 	return NewEmvWithPeriod[T](DefaultEmvPeriod)
 }
 
 // NewEmvWithPeriod function initializes a new EMV instance with the given period.
-func NewEmvWithPeriod[T helper.Number](period int) *Emv[T] {
+func NewEmvWithPeriod[T helper.Float](period int) *Emv[T] {
 	return &Emv[T]{
 		Sma: trend.NewSmaWithPeriod[T](period),
 	}


### PR DESCRIPTION
## Summary
- Follow-up to #459 (EMA/RMA/SMMA) and #496 (high-risk tier): the "Explicitly left untouched" list from #496 named 16 types (its text said 13, but explicitly listed 16 names) whose formulas only divide by a period or fixed constant — safe for `float64` today, but a hypothetical integer `T` would silently truncate that division to `0` instead of erroring. Constrains all 16 from `[T helper.Number]` to `[T helper.Float]` (struct + all constructors), then follows the same build-driven fixpoint as the two prior PRs: `go build ./...`, tighten whatever it reports, repeat until clean.
- `helper.Float` (`float32 | float64`) is a strict subset of `helper.Number`, and every in-tree caller already instantiates these with `float64`, so this is non-breaking for all in-tree code. It is technically a breaking API change for a hypothetical external caller instantiating one of these generics with an integer type (none exist in-tree).
- Purely mechanical / zero behavior change: no NaN/Inf guards, fallback values, or other runtime behavior were added or changed.
- This PR does **not** address any live float64 divide-by-zero/NaN/Inf risk — that class of issue is separately tracked (see #496's follow-up list). One additional candidate for that list was noticed while tightening a forced dependent here: **`UlcerIndex`** divides "Closings - High Closings" by "High Closings" (a moving max of closings); a zero/negative price input would produce NaN/Inf. Not fixed in this PR.

### Types touched — target list (16, from #496's "explicitly left untouched")
`trend.Aroon`, `trend.Mlr`, `trend.Mls`, `trend.Slope`, `trend.Sma`, `trend.Wma`, `trend.Hma`, `trend.Trima`, `trend.TypicalPrice`, `trend.WeightedClose`, `trend.Envelope`, `momentum.AwesomeOscillator`, `momentum.IchimokuCloud`, `volatility.DonchianChannel`, `volatility.MovingStd`, `volatility.SuperTrend`.

(`trend.Envelope`: only `NewEnvelope`/`NewEnvelopeWithSma` and the struct itself changed here — `NewEnvelopeWithEma` was already `helper.Float` from #459.)

### Forced dependents (pulled in by the build, not independently chosen)
- `momentum.Qstick` — embeds the now-`Float`-only `trend.Sma[T]`.
- `volume.Emv` — embeds the now-`Float`-only `trend.Sma[T]`.
- `volatility.Atr` — constructs the now-`Float`-only `trend.Sma[T]` in `NewAtrWithPeriod`.
- `volatility.BollingerBands` — constructs `trend.Sma[T]` and `volatility.MovingStd[T]`.
- `volatility.HistoricalVolatility` — constructs the now-`Float`-only `volatility.MovingStd[T]`.
- `volatility.UlcerIndex` — constructs `trend.Sma[T]` and `trend.MovingMax[T]` is unaffected, but the `Sma` usage forces it.
- `volatility.AnnualizedHistoricalVolatility` — embeds the now-`Float`-only `volatility.HistoricalVolatility[T]`.
- `volatility.ChandelierExit` — constructs the now-`Float`-only `volatility.Atr[T]` via `NewAtrWithPeriod`.

Verified untouched and correctly still `helper.Number` (nothing forces them): `trend.MovingMax`, `trend.MovingMin`, `trend.MovingSum`. Verified `momentum.WilliamsR` was already `helper.Float` before this PR and required no change. Verified none of the 18 types tightened by #496 (the high-risk tier) needed further changes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — zero touched files reported (pre-existing unrelated gofmt drift in untouched example/test files only)
- [x] `go test ./...` passes with zero fixture changes
- [x] Grep sweep confirms no target/dependent type still shows `helper.Number`, and nothing under `examples/`, `strategy/`, README, or legal docs was touched

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp