### PR TITLE
Add zero-denominator guards to Stochastic/Ultimate Oscillator

### DIFF
--- a/momentum/stochastic_oscillator.go
+++ b/momentum/stochastic_oscillator.go
@@ -27,6 +27,10 @@ const (
 //	K = (Closing - Lowest Low) / (Highest High - Lowest Low) * 100
 //	D = 3-Period SMA of K
 //
+// When the window is flat (Highest High == Lowest Low, i.e. price hasn't moved at all within the
+// window), %K is an undefined 0/0. It is treated as neutral (50), the midpoint of %K's own 0-100
+// scale, matching the flat-market convention established by Rsi.
+//
 // Example:
 //
 //	so := momentum.NewStochasticOscillator[float64]()
@@ -75,11 +79,14 @@ func (s *StochasticOscillator[T]) ComputeWithContext(ctx context.Context, highs,
 
 	closings = helper.SkipWithContext(ctx, closings, max(maxIdlePeriod, minIdlePeriod))
 
-	kSplice := helper.DuplicateWithContext(ctx, helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, closings, lowestSplice[0]),
-		helper.SubtractWithContext(ctx, highest, lowestSplice[1]),
-	),
-		100,
-	),
+	kSplice := helper.DuplicateWithContext(ctx, helper.Operate4WithContext(ctx, closings, lowestSplice[0], highest, lowestSplice[1], func(closing, low, high, low2 T) T {
+		denom := high - low2
+		if denom == 0 {
+			return 50
+		}
+
+		return (closing - low) / denom * 100
+	}),
 		2,
 	)
 

--- a/momentum/stochastic_oscillator_test.go
+++ b/momentum/stochastic_oscillator_test.go
@@ -76,6 +76,33 @@ func TestStochasticOscillatorDifferentMaxMinPeriods(t *testing.T) {
 	}
 }
 
+// TestStochasticOscillatorFlatMarket verifies that StochasticOscillator returns the neutral %K/%D
+// of 50 instead of NaN when the high-low range is zero (a flat market with no price movement at
+// all within the window).
+func TestStochasticOscillatorFlatMarket(t *testing.T) {
+	so := momentum.NewStochasticOscillator[float64]()
+
+	const bars = 20
+	flat := make([]float64, so.IdlePeriod()+bars)
+	for i := range flat {
+		flat[i] = 100
+	}
+
+	inputs := helper.Duplicate(helper.SliceToChan(flat), 3)
+
+	actualK, actualD := so.Compute(inputs[0], inputs[1], inputs[2])
+
+	expected := make([]float64, bars)
+	for i := range expected {
+		expected[i] = 50
+	}
+
+	err := helper.CheckEquals(actualK, helper.SliceToChan(expected), actualD, helper.SliceToChan(expected))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStochasticOscillatorString(t *testing.T) {
 	expected := "STOCHOSC(14,3)"
 	actual := momentum.NewStochasticOscillator[float64]().String()

--- a/momentum/ultimate_oscillator.go
+++ b/momentum/ultimate_oscillator.go
@@ -36,6 +36,12 @@ const (
 //	Average28 = Sum(BP for 28 periods) / Sum(TR for 28 periods)
 //	UO = 100 * [(4 * Average7) + (2 * Average14) + Average28] / (4 + 2 + 1)
 //
+// When a window's true range sum is zero (a flat market for that window, i.e. no true range at
+// all across it), its Average is an undefined 0/0. It is treated as neutral (0.5), the midpoint
+// of that Average's own 0-1 range, so that a fully flat market across all lookback windows
+// resolves to UO's own neutral midpoint of 50 (0-100 scale), matching the flat-market convention
+// established by Rsi.
+//
 // Example:
 //
 //	uo := momentum.NewUltimateOscillator[float64]()
@@ -123,9 +129,20 @@ func (u *UltimateOscillator[T]) ComputeWithContext(ctx context.Context, highs, l
 	mediumBpSum = helper.SkipWithContext(ctx, mediumBpSum, u.LongPeriod-u.MediumPeriod)
 	mediumTrSum = helper.SkipWithContext(ctx, mediumTrSum, u.LongPeriod-u.MediumPeriod)
 
-	avgShort := helper.DivideWithContext(ctx, shortBpSum, shortTrSum)
-	avgMedium := helper.DivideWithContext(ctx, mediumBpSum, mediumTrSum)
-	avgLong := helper.DivideWithContext(ctx, longBpSum, longTrSum)
+	// Average = Sum(BP) / Sum(TR). A flat window has no true range at all, so Sum(TR) is zero and
+	// the ratio is an undefined 0/0; treat it as neutral (0.5, the midpoint of this ratio's own
+	// 0-1 range) instead of propagating NaN.
+	average := func(bpSum, trSum T) T {
+		if trSum == 0 {
+			return 0.5
+		}
+
+		return bpSum / trSum
+	}
+
+	avgShort := helper.OperateWithContext(ctx, shortBpSum, shortTrSum, average)
+	avgMedium := helper.OperateWithContext(ctx, mediumBpSum, mediumTrSum, average)
+	avgLong := helper.OperateWithContext(ctx, longBpSum, longTrSum, average)
 
 	// UO = 100 * [(4 * Average7) + (2 * Average14) + Average28] / (4 + 2 + 1)
 	// (4 + 2 + 1) = 7

--- a/momentum/ultimate_oscillator_test.go
+++ b/momentum/ultimate_oscillator_test.go
@@ -41,3 +41,30 @@ func TestUltimateOscillator(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestUltimateOscillatorFlatMarket verifies that UltimateOscillator returns its neutral value of
+// 50 instead of NaN when there is no true range at all across the lookback windows (a flat
+// market with no price movement).
+func TestUltimateOscillatorFlatMarket(t *testing.T) {
+	uo := momentum.NewUltimateOscillator[float64]()
+
+	bars := uo.IdlePeriod() + 20
+	flat := make([]float64, bars)
+	for i := range flat {
+		flat[i] = 100
+	}
+
+	inputs := helper.Duplicate(helper.SliceToChan(flat), 3)
+
+	actual := helper.ChanToSlice(uo.Compute(inputs[0], inputs[1], inputs[2]))
+
+	if len(actual) == 0 {
+		t.Fatal("expected at least one UO value")
+	}
+
+	for _, v := range actual {
+		if v != 50 {
+			t.Fatalf("expected UO of 50 for flat market, got %v", v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `StochasticOscillator.ComputeWithContext` computed `%K = (Closing - Lowest Low) / (Highest High - Lowest Low) * 100`. When a window is flat (`Highest High == Lowest Low`, i.e. no price movement at all within the window), the denominator is `0` and the numerator is also `0` (since Closing must equal both when the range is flat), so `%K` was `NaN` instead of a sane value. Guarded the division and fall back to **50** — the midpoint of `%K`'s own documented 0-100 scale — matching the neutral-midpoint convention `Rsi` established for its own flat-market 0/0 case (#455).
- `UltimateOscillator.ComputeWithContext` computes three `Average = Sum(BP) / Sum(TR)` ratios (short/medium/long lookback windows) before combining them into the final 0-100 UO value. When a window has no true range at all (flat market for that window), `Sum(TR)` is `0` and `Sum(BP)` is also `0`, so that window's `Average` was `NaN`. Guarded each of the three divisions and fall back to **0.5** — the midpoint of that ratio's own 0-1 range. This choice is deliberate: when *all three* windows are simultaneously flat (the only way a fully flat synthetic/real series can occur, since the long period's window is a superset of the medium and short ones), the weighted combination `100 * [(4*0.5)+(2*0.5)+0.5]/7` resolves to exactly **50**, i.e. UO's own documented neutral midpoint on its 0-100 scale — consistent with the sibling fix in this PR and with `Rsi`.
- Followed the existing guard-code style used for the identical situation in `momentum/ibs.go` and `volatility/chop.go` (a denominator check immediately before the division, returning a documented fallback), and documented the chosen fallback + reasoning in each type's doc comment.
- This is a follow-up to #496 ("Tighten high-risk indicators to helper.Float"), which fixed the separate integer-truncation gap for these same types but deliberately left the zero-denominator guards for later.

## Test plan
- [x] Added `TestStochasticOscillatorFlatMarket` (`momentum/stochastic_oscillator_test.go`): a constant high/low/close series, asserting both `%K` and `%D` are exactly `50` for every emitted bar (not `NaN`).
- [x] Added `TestUltimateOscillatorFlatMarket` (`momentum/ultimate_oscillator_test.go`): a constant high/low/close series, asserting UO is exactly `50` for every emitted bar (not `NaN`).
- [x] Verified the existing CSV-fixture-based `TestStochasticOscillator`, `TestStochasticOscillatorDifferentMaxMinPeriods`, and `TestUltimateOscillator` are unaffected — none of the fixtures contain a flat/zero-range bar (checked via `High == Low`), and all three still pass with unchanged expected output.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean for the changed files)
- [x] `go test ./...` (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp