### PR TITLE
Add zero-denominator guards to 6 volatility indicators

### DIFF
--- a/volatility/acceleration_bands.go
+++ b/volatility/acceleration_bands.go
@@ -24,6 +24,12 @@ const (
 //	Middle Band = SMA(Closing)
 //	Lower Band = SMA(Low * (1 - 4 * (High - Low) / (High + Low)))
 //
+// When a bar has both High and Low equal to zero (a zero-priced or
+// untraded instrument), the (High - Low) / (High + Low) ratio is an
+// undefined 0/0. It falls back to 0, leaving that bar's contribution to
+// the bands unadjusted, since there is no price range to derive a
+// directional adjustment from.
+//
 // Example:
 //
 //	accelerationBands := NewAccelerationBands[float64]()
@@ -45,8 +51,15 @@ func (a *AccelerationBands[T]) ComputeWithContext(ctx context.Context, high, low
 	highs := helper.DuplicateWithContext(ctx, high, 3)
 	lows := helper.DuplicateWithContext(ctx, low, 3)
 
-	ks := helper.DuplicateWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, highs[0], lows[0]),
+	ks := helper.DuplicateWithContext(ctx, helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, highs[0], lows[0]),
 		helper.AddWithContext(ctx, highs[1], lows[1]),
+		func(diff, sum T) T {
+			if sum == 0 {
+				return 0
+			}
+
+			return diff / sum
+		},
 	),
 		2,
 	)

--- a/volatility/acceleration_bands_test.go
+++ b/volatility/acceleration_bands_test.go
@@ -5,6 +5,7 @@
 package volatility_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/cinar/indicator/v2/helper"
@@ -47,6 +48,69 @@ func TestAccelerationBands(t *testing.T) {
 	err = helper.CheckEquals(actualUpper, upper, actualMiddle, middle, actualLower, lower)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAccelerationBandsZeroPricedInstrument(t *testing.T) {
+	period := volatility.DefaultAccelerationBandsPeriod
+	length := period + 5
+
+	highs := make([]float64, length)
+	lows := make([]float64, length)
+	closings := make([]float64, length)
+
+	ab := volatility.NewAccelerationBands[float64]()
+	actualUpper, actualMiddle, actualLower := ab.Compute(
+		helper.SliceToChan(highs),
+		helper.SliceToChan(lows),
+		helper.SliceToChan(closings),
+	)
+
+	// The three output channels share upstream duplicated/fanned-out
+	// channels internally, so they must be drained concurrently rather
+	// than one at a time, or the pipeline deadlocks.
+	var upperValues, middleValues, lowerValues []float64
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		upperValues = helper.ChanToSlice(actualUpper)
+	}()
+
+	go func() {
+		defer wg.Done()
+		middleValues = helper.ChanToSlice(actualMiddle)
+	}()
+
+	go func() {
+		defer wg.Done()
+		lowerValues = helper.ChanToSlice(actualLower)
+	}()
+
+	wg.Wait()
+
+	if len(upperValues) == 0 {
+		t.Fatal("expected at least one value")
+	}
+
+	for i, v := range upperValues {
+		if v != 0 {
+			t.Fatalf("expected upper band 0 for zero-priced instrument at %d, got %v", i, v)
+		}
+	}
+
+	for i, v := range middleValues {
+		if v != 0 {
+			t.Fatalf("expected middle band 0 for zero-priced instrument at %d, got %v", i, v)
+		}
+	}
+
+	for i, v := range lowerValues {
+		if v != 0 {
+			t.Fatalf("expected lower band 0 for zero-priced instrument at %d, got %v", i, v)
+		}
 	}
 }
 

--- a/volatility/bollinger_band_width.go
+++ b/volatility/bollinger_band_width.go
@@ -20,6 +20,10 @@ import (
 //
 //	Band Width = (Upper Band - Lower Band) / Middle BollingerBandWidth
 //
+// If the middle band (an SMA of the closing price) is zero — only
+// possible for a zero-priced instrument, an extremely unlikely
+// real-world scenario — Band Width falls back to 0 instead of NaN/Inf.
+//
 // Example:
 //
 //	bbw := NewBollingerBandWidth[float64]()
@@ -40,9 +44,13 @@ func NewBollingerBandWidth[T helper.Float]() *BollingerBandWidth[T] {
 func (b *BollingerBandWidth[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T {
 	upper, middle, lower := b.BollingerBands.ComputeWithContext(ctx, c)
 
-	return helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, upper, lower),
-		middle,
-	)
+	return helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, upper, lower), middle, func(diff, middle T) T {
+		if middle == 0 {
+			return 0
+		}
+
+		return diff / middle
+	})
 }
 
 // IdlePeriod is the initial period that Bollinger Band Width won't yield any results.

--- a/volatility/bollinger_band_width_test.go
+++ b/volatility/bollinger_band_width_test.go
@@ -38,6 +38,24 @@ func TestBollingerBandWidth(t *testing.T) {
 	}
 }
 
+func TestBollingerBandWidthZeroPricedInstrument(t *testing.T) {
+	length := volatility.DefaultBollingerBandsPeriod + 5
+	closings := make([]float64, length)
+
+	bbw := volatility.NewBollingerBandWidth[float64]()
+	actual := helper.ChanToSlice(bbw.Compute(helper.SliceToChan(closings)))
+
+	if len(actual) == 0 {
+		t.Fatal("expected at least one value")
+	}
+
+	for i, v := range actual {
+		if v != 0 {
+			t.Fatalf("expected band width 0 for zero-priced instrument at %d, got %v", i, v)
+		}
+	}
+}
+
 func TestBollingerBandWidthString(t *testing.T) {
 	expected := "BBW(20)"
 	actual := volatility.NewBollingerBandWidth[float64]().String()

--- a/volatility/percent_b.go
+++ b/volatility/percent_b.go
@@ -15,6 +15,13 @@ import (
 // PercentB represents the parameters for calculating the %B indicator.
 //
 //	%B = (Close - Lower Band) / (Upper Band - Lower Band)
+//
+// %B is expressed on a 0-1 scale locating price within the bands (0 at
+// the lower band, 1 at the upper band). When the bands collapse to zero
+// width (upper == lower, i.e. zero rolling standard deviation — a flat
+// price window), price sits exactly at that single collapsed band value.
+// The ratio is an undefined 0/0, so it falls back to the neutral
+// midpoint 0.5.
 type PercentB[T helper.Float] struct {
 	// BollingerBands is the underlying Bollinger Bands indicator used for calculations.
 	BollingerBands *BollingerBands[T]
@@ -46,8 +53,13 @@ func (p *PercentB[T]) ComputeWithContext(ctx context.Context, closings <-chan T)
 	go helper.DrainWithContext(ctx, middleBands)
 
 	return helper.Operate3WithContext(ctx, upperBands, lowerBands, closingsSplice[1], func(upperBand, lowerBand, closing T) T {
+		denom := upperBand - lowerBand
+		if denom == 0 {
+			return 0.5
+		}
+
 		// %B = (Close - Lower Band) / (Upper Band - Lower Band)
-		return (closing - lowerBand) / (upperBand - lowerBand)
+		return (closing - lowerBand) / denom
 	})
 }
 

--- a/volatility/percent_b_test.go
+++ b/volatility/percent_b_test.go
@@ -62,6 +62,28 @@ func TestPercentB(t *testing.T) {
 	}
 }
 
+func TestPercentBFlatMarket(t *testing.T) {
+	percentB := volatility.NewPercentB[float64]()
+	length := percentB.IdlePeriod() + 20
+
+	closings := make([]float64, length)
+	for i := range closings {
+		closings[i] = 100
+	}
+
+	actual := helper.ChanToSlice(percentB.Compute(helper.SliceToChan(closings)))
+
+	if len(actual) == 0 {
+		t.Fatal("expected at least one %B value")
+	}
+
+	for i, v := range actual {
+		if v != 0.5 {
+			t.Fatalf("expected %%B of 0.5 for flat market at %d, got %v", i, v)
+		}
+	}
+}
+
 func TestPercentBString(t *testing.T) {
 	expected := "%B(10)"
 	actual := volatility.NewPercentBWithPeriod[float64](10).String()

--- a/volatility/po.go
+++ b/volatility/po.go
@@ -24,6 +24,13 @@ const (
 //	PH = Max(period, (high + MLS(period, x, high)))
 //	PO = 100 * (Closing - PL) / (PH - PL)
 //
+// PO is expressed on a 0-100 scale locating price within the projected
+// range. When PH and PL collapse to the same value (a flat window, e.g.
+// unchanged highs, lows, and closings), the projected range has zero
+// width, an undefined 0/0. It falls back to the neutral midpoint 50,
+// mirroring the flat-market convention used by RSI and other 0-100
+// range-position oscillators.
+//
 // Example:
 //
 //	po := volatility.NewPo()
@@ -90,15 +97,15 @@ func (p *Po[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-
 	// PO = 100 * (Closing - PL) / (PH - PL)
 	closingsSplice[1] = helper.SkipWithContext(ctx, closingsSplice[1], p.mls.IdlePeriod()+p.min.IdlePeriod())
 
-	po := helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, closingsSplice[1],
-		plSplice[0],
-	),
-		helper.SubtractWithContext(ctx, ph,
-			plSplice[1],
-		),
-	),
-		T(100),
-	)
+	phMinusPl := helper.SubtractWithContext(ctx, ph, plSplice[1])
+
+	po := helper.Operate3WithContext(ctx, closingsSplice[1], plSplice[0], phMinusPl, func(closing, pl, denom T) T {
+		if denom == 0 {
+			return 50
+		}
+
+		return 100 * (closing - pl) / denom
+	})
 
 	return po
 }

--- a/volatility/po_test.go
+++ b/volatility/po_test.go
@@ -42,6 +42,37 @@ func TestPo(t *testing.T) {
 	}
 }
 
+func TestPoFlatMarket(t *testing.T) {
+	po := volatility.NewPo[float64]()
+	length := po.IdlePeriod() + 20
+
+	highs := make([]float64, length)
+	lows := make([]float64, length)
+	closings := make([]float64, length)
+
+	for i := range highs {
+		highs[i] = 100
+		lows[i] = 100
+		closings[i] = 100
+	}
+
+	actual := helper.ChanToSlice(po.Compute(
+		helper.SliceToChan(highs),
+		helper.SliceToChan(lows),
+		helper.SliceToChan(closings),
+	))
+
+	if len(actual) == 0 {
+		t.Fatal("expected at least one PO value")
+	}
+
+	for i, v := range actual {
+		if v != 50 {
+			t.Fatalf("expected PO of 50 for flat market at %d, got %v", i, v)
+		}
+	}
+}
+
 func TestPoString(t *testing.T) {
 	expected := "PO(14)"
 	actual := volatility.NewPo[float64]().String()

--- a/volatility/ulcer_index.go
+++ b/volatility/ulcer_index.go
@@ -26,6 +26,15 @@ const (
 //	Squared Average = Sma(period, Percent Drawdown * Percent Drawdown)
 //	Ulcer Index = Sqrt(Squared Average)
 //
+// High Closings is a rolling max of Closings, so it is zero or negative
+// only when every closing in the window is zero or negative — a
+// degenerate/invalid-price input (e.g. a worthless or corrupted feed),
+// not a normal market condition. Rather than propagate a NaN/Inf (or
+// panic, which would crash the whole streaming pipeline for one bad
+// window), that bar's Percentage Drawdown falls back to 0, the neutral
+// "no computable drawdown" value: it contributes no signal to the
+// Squared Average instead of a fabricated one.
+//
 // Example:
 //
 //	ui := volatility.NewUlcerIndex[float64]()
@@ -55,8 +64,15 @@ func (u *UlcerIndex[T]) ComputeWithContext(ctx context.Context, closings <-chan 
 	//	Percentage Drawdown = 100 * ((Closings - High Closings) / High Closings)
 	closingsSplice[1] = helper.SkipWithContext(ctx, closingsSplice[1], movingMax.Period-1)
 
-	percentageDrawdown := helper.MultiplyByWithContext(ctx, helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, closingsSplice[1], highsSplice[0]),
+	percentageDrawdown := helper.MultiplyByWithContext(ctx, helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, closingsSplice[1], highsSplice[0]),
 		highsSplice[1],
+		func(diff, highClosing T) T {
+			if highClosing <= 0 {
+				return 0
+			}
+
+			return diff / highClosing
+		},
 	),
 		100,
 	)

--- a/volatility/ulcer_index_test.go
+++ b/volatility/ulcer_index_test.go
@@ -38,6 +38,34 @@ func TestUlcerIndex(t *testing.T) {
 	}
 }
 
+func TestUlcerIndexZeroOrNegativePrice(t *testing.T) {
+	ui := volatility.NewUlcerIndex[float64]()
+	length := ui.IdlePeriod() + 20
+
+	// A degenerate closing series that is zero or negative throughout, so
+	// the rolling High Closings (a moving max) is never positive.
+	closings := make([]float64, length)
+	for i := range closings {
+		if i%2 == 0 {
+			closings[i] = 0
+		} else {
+			closings[i] = -1
+		}
+	}
+
+	actual := helper.ChanToSlice(ui.Compute(helper.SliceToChan(closings)))
+
+	if len(actual) == 0 {
+		t.Fatal("expected at least one Ulcer Index value")
+	}
+
+	for i, v := range actual {
+		if v != 0 {
+			t.Fatalf("expected Ulcer Index of 0 for non-positive prices at %d, got %v", i, v)
+		}
+	}
+}
+
 func TestUlcerIndexString(t *testing.T) {
 	expected := "ULCERINDEX(14)"
 	actual := volatility.NewUlcerIndex[float64]().String()

--- a/volatility/z_score.go
+++ b/volatility/z_score.go
@@ -22,6 +22,12 @@ const (
 //
 //	Z-Score = (Price - SMA) / StdDev
 //
+// When every value in the window is identical, StdDev is 0 and Price
+// equals the SMA too, so the ratio is an undefined 0/0. It falls back to
+// 0, which is the mathematically correct answer here (not merely a
+// convention): a value identical to every other value in its window
+// deviates exactly 0 standard deviations from the mean.
+//
 // Example:
 //
 //	z := NewZScore[float64]()
@@ -54,7 +60,13 @@ func (z *ZScore[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T
 	stdChan := std.ComputeWithContext(ctx, cs[1])
 	priceChan := helper.SkipWithContext(ctx, cs[2], z.IdlePeriod())
 
-	return helper.DivideWithContext(ctx, helper.SubtractWithContext(ctx, priceChan, smaChan), stdChan)
+	return helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, priceChan, smaChan), stdChan, func(diff, std T) T {
+		if std == 0 {
+			return 0
+		}
+
+		return diff / std
+	})
 }
 
 // IdlePeriod is the initial period that Z-Score won't yield any results.

--- a/volatility/z_score_test.go
+++ b/volatility/z_score_test.go
@@ -39,6 +39,28 @@ func TestZScore(t *testing.T) {
 	}
 }
 
+func TestZScoreFlatMarket(t *testing.T) {
+	z := volatility.NewZScore[float64]()
+	length := z.IdlePeriod() + 20
+
+	closings := make([]float64, length)
+	for i := range closings {
+		closings[i] = 100
+	}
+
+	actual := helper.ChanToSlice(z.Compute(helper.SliceToChan(closings)))
+
+	if len(actual) == 0 {
+		t.Fatal("expected at least one Z-Score value")
+	}
+
+	for i, v := range actual {
+		if v != 0 {
+			t.Fatalf("expected Z-Score of 0 for flat market at %d, got %v", i, v)
+		}
+	}
+}
+
 func TestZScoreString(t *testing.T) {
 	z := volatility.NewZScoreWithPeriod[float64](14)
 	expected := "ZSCORE(14)"


### PR DESCRIPTION
## Summary
Following up on "Tighten high-risk indicators to helper.Float" (#496), which fixed the integer-truncation type-safety gap but deliberately left zero-denominator handling out of scope, this guards six `volatility/` indicators that divide by a value that can legitimately (or degenerately) be zero on real `float64` market data, each with a documented, reasoned fallback instead of propagating `NaN`/`Inf`. Guard style follows the existing precedent in `volatility/chop.go` and `momentum/ibs.go` (an `if denom == 0 { return ... }` check inlined into the division), and the neutral-midpoint reasoning follows `momentum/rsi.go`'s flat-market fix (#455).

- **`AccelerationBands`**: the band-width factor `(High - Low) / (High + Low)` divides by `(High + Low)`, not `(High - Low)` as initially suspected — reading the code confirmed this. That sum is zero only when High and Low are both zero (a zero-priced/untraded bar), an undefined 0/0 (since High - Low is then also 0). Falls back to `0`, leaving that bar's contribution to the upper/lower bands unadjusted (equal to the plain, un-widened High/Low) — there is no price range to derive a directional adjustment from.
- **`BollingerBandWidth`**: divides `(Upper - Lower)` by the middle band (an SMA of closing price). Zero only for a zero-priced instrument — extremely unlikely in practice, lowest priority of the group. Falls back to `0`.
- **`Po`** (Projection Oscillator): confirmed the formula is `100 * (Closing - PL) / (PH - PL)`, a 0-100-scale "position within a projected range" measure, structurally the same family as RSI/Stochastic. `PH - PL` collapses to zero width on a flat window (unchanged highs/lows/closings), an undefined 0/0. Falls back to the neutral midpoint `50`, mirroring RSI's flat-market fix.
- **`PercentB`**: confirmed from its formula and existing `ExamplePercentB` test (expected output `0.3`, not `30`) that %B is on a 0-1 scale. When the bands collapse to zero width (`upper == lower`, i.e. zero rolling std dev — a flat price window), price sits exactly at that single collapsed band value, an undefined 0/0. Falls back to the neutral midpoint `0.5`.
- **`ZScore`**: `(Price - SMA) / StdDev`. When every value in the window is identical, StdDev is 0 (and Price == SMA too). Unlike the other four, `0` here is not a convention but the mathematically correct answer: a value identical to every other value in its window deviates exactly 0 standard deviations from the mean.
- **`UlcerIndex`** (added mid-flight per a sibling PR's finding — "Tighten remaining low-risk indicators to helper.Float" — that flagged this same-package risk): `Percentage Drawdown = 100 * (Closings - HighClosings) / HighClosings`, where HighClosings is a rolling max of Closings. HighClosings is zero or negative only when every closing in the window is non-positive — a degenerate/invalid-price input (worthless or corrupted feed), not a normal flat-market condition like the other five. Weighed a documented panic/error against a safe fallback: a panic in one bad window would crash the whole streaming (goroutine/channel) pipeline for every indicator sharing that context, which is a worse failure mode than a numeric fallback in this library's existing all-guards-not-panics convention (`chop.go`, `ibs.go`, `rsi.go`). Falls back to `0` (no computable drawdown contributes no signal to the squared average) rather than panicking.

## Test plan
- [x] Added one test per type with a deliberately flat/zero-range (or zero-std-dev / non-positive-price, for `ZScore`/`UlcerIndex`) synthetic input, confirming the documented fallback fires instead of `NaN`/`Inf`/a panic: `TestAccelerationBandsZeroPricedInstrument`, `TestBollingerBandWidthZeroPricedInstrument`, `TestPoFlatMarket`, `TestPercentBFlatMarket`, `TestZScoreFlatMarket`, `TestUlcerIndexZeroOrNegativePrice`.
- [x] `TestAccelerationBandsZeroPricedInstrument` initially deadlocked `go test` for the whole `volatility` package (timed out at Go's default 600s and dumped goroutines) because it drained the three `AccelerationBands` output channels (`upper`/`middle`/`lower`) one at a time — they share upstream duplicated/fanned-out channels internally and must be drained concurrently, the same reason the existing fixture-based test uses `helper.CheckEquals` across all three at once. Fixed by draining all three concurrently via goroutines + `sync.WaitGroup`.
- [x] Verified existing fixture-based tests for all 6 types (`TestAccelerationBands`, `TestBollingerBandWidth`, `TestPo`, `TestPercentB`, `TestZScore`, `TestUlcerIndex`) are unaffected for normal (non-degenerate) input — none of their CSV fixtures contain a flat/zero-range window that the new guards would touch, and all pass unchanged.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean for all files touched by this change)
- [x] `go test ./...` (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp