### PR TITLE
Add ChanToSlices helper for safely draining multi-output channels

### DIFF
--- a/helper/chan_to_slices.go
+++ b/helper/chan_to_slices.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper
+
+import "sync"
+
+// ChanToSlices converts multiple channels of type T to slices of type T, draining all of the
+// given channels concurrently on their own goroutines. This is the safe way to fully consume
+// the unbuffered output channels returned by DuplicateWithContext (or any other multi-output
+// producer), since draining them one at a time would block the producer forever once its
+// internal buffer, if any, is exhausted.
+//
+// The returned slices are in the same order as the given channels.
+//
+// Example:
+//
+//	c1 := make(chan int, 4)
+//	c2 := make(chan int, 4)
+//
+//	c1 <- 1
+//	c2 <- 2
+//	close(c1)
+//	close(c2)
+//
+//	fmt.Println(helper.ChanToSlices(c1, c2)) // [[1] [2]]
+func ChanToSlices[T any](chans ...<-chan T) [][]T {
+	slices := make([][]T, len(chans))
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(len(chans))
+
+	for i, c := range chans {
+		go func(i int, c <-chan T) {
+			defer waitGroup.Done()
+
+			slices[i] = ChanToSlice(c)
+		}(i, c)
+	}
+
+	waitGroup.Wait()
+
+	return slices
+}

--- a/helper/chan_to_slices_test.go
+++ b/helper/chan_to_slices_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper_test
+
+import (
+	"context"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+func TestChanToSlicesTwoChannels(t *testing.T) {
+	input := []int{1, 2, 3, 4}
+	c := helper.SliceToChan(input)
+
+	outputs := helper.DuplicateWithContext(context.Background(), c, 2)
+
+	actual := helper.ChanToSlices(outputs...)
+
+	expected := [][]int{
+		{1, 2, 3, 4},
+		{1, 2, 3, 4},
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}
+
+func TestChanToSlicesMultipleChannels(t *testing.T) {
+	input := []int{5, 10, 15}
+	c := helper.SliceToChan(input)
+
+	const count = 4
+
+	outputs := helper.DuplicateWithContext(context.Background(), c, count)
+
+	actual := helper.ChanToSlices(outputs...)
+
+	if len(actual) != count {
+		t.Fatalf("actual length %d expected %d", len(actual), count)
+	}
+
+	for i, slice := range actual {
+		if !reflect.DeepEqual(slice, input) {
+			t.Fatalf("index %d actual %v expected %v", i, slice, input)
+		}
+	}
+}
+
+func TestChanToSlicesDoesNotDeadlockOnUnbufferedChannels(t *testing.T) {
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	first := make(chan int)
+	second := make(chan int)
+	third := make(chan int)
+
+	go func() {
+		defer close(first)
+		defer close(second)
+		defer close(third)
+
+		for i := 0; i < 5; i++ {
+			first <- i
+			second <- i
+			third <- i
+		}
+	}()
+
+	done := make(chan [][]int)
+
+	go func() {
+		done <- helper.ChanToSlices(first, second, third)
+	}()
+
+	select {
+	case actual := <-done:
+		expected := []int{0, 1, 2, 3, 4}
+
+		for i, slice := range actual {
+			if !reflect.DeepEqual(slice, expected) {
+				t.Fatalf("index %d actual %v expected %v", i, slice, expected)
+			}
+		}
+
+	case <-time.After(time.Second):
+		t.Fatal("ChanToSlices deadlocked draining unbuffered channels")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+
+	current := runtime.NumGoroutine()
+	if current > baseline+2 {
+		t.Fatalf("Goroutine leak detected. Baseline: %d, Current: %d", baseline, current)
+	}
+}

--- a/helper/duplicate.go
+++ b/helper/duplicate.go
@@ -15,6 +15,12 @@ func Duplicate[T any](input <-chan T, count int) []<-chan T {
 
 // DuplicateWithContext duplicates a given receive-only channel by reading each value coming out of
 // that channel and sending them on requested number of new output channels, supporting context cancellation.
+//
+// The returned output channels are unbuffered (regardless of the input channel's buffering), so all of
+// them must be actively read concurrently. Fully draining one output channel before starting to read
+// another will block the producer goroutine forever, since it sends to every output channel for each
+// value before moving on to the next. Use ChanToSlices to safely drain all of the returned channels
+// concurrently, or otherwise ensure each channel is read from its own goroutine.
 func DuplicateWithContext[T any](ctx context.Context, input <-chan T, count int) []<-chan T {
 	outputs := make([]chan T, count)
 	result := make([]<-chan T, count)


### PR DESCRIPTION
## Summary
- `helper.DuplicateWithContext` fans out into N unbuffered output channels; all of them must be actively drained concurrently or the producer goroutine deadlocks. Several engineers independently hit this while writing tests for multi-output indicators (`AccelerationBands`, `Kdj`/`SlowStochastic`/`Stochastic`, `StochasticOscillator`).
- Adds `helper.ChanToSlices(chans ...<-chan T) [][]T`, a general-purpose (not test-only) helper that drains each channel concurrently on its own goroutine via a `sync.WaitGroup` and returns the collected slices in the same order as the input channels, matching the style of the existing `helper.ChanToSlice`.
- Documents the unbuffered/must-drain-concurrently hazard directly on `DuplicateWithContext`'s doc comment, pointing at `ChanToSlices` as the supported safe way to consume its outputs.
- Purely additive: no existing indicator signatures/behavior changed, no README or legal/disclaimer content touched, nothing moved between `examples/` and `strategy/`.

## Test plan
- [x] Added `helper/chan_to_slices_test.go` covering: 2 channels, 4 channels (via `DuplicateWithContext`), and a goroutine-leak/deadlock check modeled on `TestCciCancellation` in `trend/cci_test.go` (unbuffered channels, `runtime.NumGoroutine()` before/after, `time.Sleep` + `runtime.GC()`, plus a `time.After` deadlock guard).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no output from files touched by this change (pre-existing unformatted files elsewhere are unrelated and unchanged by this PR)
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp