### PR TITLE
Consolidate zero-denominator guards into helper.SafeDivide

### DIFF
--- a/helper/safe_divide.go
+++ b/helper/safe_divide.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper
+
+// SafeDivide divides the given numerator by the given denominator, and
+// returns the given fallback instead of dividing by zero when the
+// denominator is zero.
+//
+// Several indicators guard a division whose denominator can be
+// legitimately zero (e.g., a flat high-low range, or a flat window with
+// no true range at all), and return a neutral value instead of letting
+// the division produce NaN or Inf. This centralizes that guard so each
+// indicator only needs to supply its own neutral fallback.
+//
+// Example:
+//
+//	n := helper.SafeDivide(4.0, 2.0, 0.5)
+//	fmt.Println(n) // 2
+//
+//	n = helper.SafeDivide(4.0, 0.0, 0.5)
+//	fmt.Println(n) // 0.5
+func SafeDivide[T Number](numerator, denominator, fallback T) T {
+	if denominator == 0 {
+		return fallback
+	}
+
+	return numerator / denominator
+}

--- a/helper/safe_divide_test.go
+++ b/helper/safe_divide_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021-2026 The Indicator Authors.
+// The source code is provided under GNU AGPLv3 License.
+// https://github.com/cinar/indicator
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/cinar/indicator/v2/helper"
+)
+
+func TestSafeDivide(t *testing.T) {
+	input := 4.0
+	divider := 2.0
+	fallback := 0.5
+	expected := 2.0
+
+	actual := helper.SafeDivide(input, divider, fallback)
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}
+
+func TestSafeDivideByZero(t *testing.T) {
+	input := 4.0
+	divider := 0.0
+	fallback := 0.5
+	expected := fallback
+
+	actual := helper.SafeDivide(input, divider, fallback)
+
+	if actual != expected {
+		t.Fatalf("actual %v expected %v", actual, expected)
+	}
+}

--- a/momentum/ibs.go
+++ b/momentum/ibs.go
@@ -31,10 +31,7 @@ func NewInternalBarStrength[T helper.Float]() *InternalBarStrength[T] {
 func (ibs *InternalBarStrength[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-chan T) <-chan T {
 	return helper.Operate3WithContext(ctx, highs, lows, closings, func(high, low, closing T) T {
 		denom := high - low
-		if denom == 0 {
-			return 0
-		}
-		return (closing - low) / denom
+		return helper.SafeDivide(closing-low, denom, T(0))
 	})
 }
 

--- a/momentum/stochastic_oscillator.go
+++ b/momentum/stochastic_oscillator.go
@@ -81,11 +81,8 @@ func (s *StochasticOscillator[T]) ComputeWithContext(ctx context.Context, highs,
 
 	kSplice := helper.DuplicateWithContext(ctx, helper.Operate4WithContext(ctx, closings, lowestSplice[0], highest, lowestSplice[1], func(closing, low, high, low2 T) T {
 		denom := high - low2
-		if denom == 0 {
-			return 50
-		}
-
-		return (closing - low) / denom * 100
+		// Fallback of 0.5 pre-scales to 50 once multiplied by 100 below.
+		return helper.SafeDivide(closing-low, denom, T(0.5)) * 100
 	}),
 		2,
 	)

--- a/momentum/ultimate_oscillator.go
+++ b/momentum/ultimate_oscillator.go
@@ -133,11 +133,7 @@ func (u *UltimateOscillator[T]) ComputeWithContext(ctx context.Context, highs, l
 	// the ratio is an undefined 0/0; treat it as neutral (0.5, the midpoint of this ratio's own
 	// 0-1 range) instead of propagating NaN.
 	average := func(bpSum, trSum T) T {
-		if trSum == 0 {
-			return 0.5
-		}
-
-		return bpSum / trSum
+		return helper.SafeDivide(bpSum, trSum, T(0.5))
 	}
 
 	avgShort := helper.OperateWithContext(ctx, shortBpSum, shortTrSum, average)

--- a/trend/bop.go
+++ b/trend/bop.go
@@ -36,11 +36,7 @@ func (i *Bop[T]) ComputeWithContext(ctx context.Context, opening, high, low, clo
 	denominator := helper.SubtractWithContext(ctx, high, low)
 
 	return helper.OperateWithContext(ctx, numerator, denominator, func(num, denom T) T {
-		if denom == 0 {
-			return 0
-		}
-
-		return num / denom
+		return helper.SafeDivide(num, denom, T(0))
 	})
 }
 

--- a/trend/cfo.go
+++ b/trend/cfo.go
@@ -60,11 +60,7 @@ func (c *Cfo[T]) ComputeWithContext(ctx context.Context, closing <-chan T) <-cha
 	numerator := helper.SubtractWithContext(ctx, closingPriceSplice[0], forecast)
 
 	return helper.OperateWithContext(ctx, numerator, closingPriceSplice[1], func(num, price T) T {
-		if price == 0 {
-			return 0
-		}
-
-		return (num / price) * T(100)
+		return helper.SafeDivide(num, price, T(0)) * T(100)
 	})
 }
 

--- a/trend/kama.go
+++ b/trend/kama.go
@@ -90,11 +90,7 @@ func (k *Kama[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-c
 
 	//	Efficiency Ratio (ER) = Direction / Volatility
 	ers := helper.OperateWithContext(ctx, directions, volatilitys, func(direction, volatility T) T {
-		if volatility == 0 {
-			return 0
-		}
-
-		return direction / volatility
+		return helper.SafeDivide(direction, volatility, T(0))
 	})
 
 	//	Smoothing Constant (SC) = (ER * (2/(Fast + 1) - 2/(Slow + 1)) + (2/(Slow + 1)))^2

--- a/trend/kdj.go
+++ b/trend/kdj.go
@@ -92,11 +92,8 @@ func (kdj *Kdj[T]) ComputeWithContext(ctx context.Context, high, low, closing <-
 	denominator := helper.SubtractWithContext(ctx, highest, lowests[1])
 
 	rsv := helper.OperateWithContext(ctx, numerator, denominator, func(num, denom T) T {
-		if denom == 0 {
-			return 50
-		}
-
-		return (num / denom) * 100
+		// Fallback of 0.5 pre-scales to 50 once multiplied by 100 below.
+		return helper.SafeDivide(num, denom, T(0.5)) * 100
 	})
 
 	ks := helper.DuplicateWithContext(ctx, kdj.Sma1.ComputeWithContext(ctx, rsv),

--- a/trend/slow_stochastic.go
+++ b/trend/slow_stochastic.go
@@ -88,11 +88,8 @@ func (s *SlowStochastic[T]) ComputeWithContext(ctx context.Context, values <-cha
 	denominator := helper.SubtractWithContext(ctx, highest, lowestSplice[1])
 
 	fastK := helper.OperateWithContext(ctx, numerator, denominator, func(num, denom T) T {
-		if denom == 0 {
-			return 50
-		}
-
-		return (num / denom) * 100
+		// Fallback of 0.5 pre-scales to 50 once multiplied by 100 below.
+		return helper.SafeDivide(num, denom, T(0.5)) * 100
 	})
 
 	slowKSma := NewSmaWithPeriod[T](s.KPeriod)

--- a/trend/stochastic.go
+++ b/trend/stochastic.go
@@ -78,11 +78,8 @@ func (s *Stochastic[T]) ComputeWithContext(ctx context.Context, values <-chan T)
 	denominator := helper.SubtractWithContext(ctx, highest, lowestSplice[1])
 
 	k := helper.OperateWithContext(ctx, numerator, denominator, func(num, denom T) T {
-		if denom == 0 {
-			return 50
-		}
-
-		return (num / denom) * 100
+		// Fallback of 0.5 pre-scales to 50 once multiplied by 100 below.
+		return helper.SafeDivide(num, denom, T(0.5)) * 100
 	})
 
 	kSplice := helper.DuplicateWithContext(ctx, k, 2)

--- a/trend/tsi.go
+++ b/trend/tsi.go
@@ -75,11 +75,7 @@ func (t *Tsi[T]) ComputeWithContext(ctx context.Context, closings <-chan T) <-ch
 
 	// TSI = (PCDS / APCDS) * 100
 	tsi := helper.OperateWithContext(ctx, pcds, apcds, func(pcd, apcd T) T {
-		if apcd == 0 {
-			return 0
-		}
-
-		return (pcd / apcd) * T(100)
+		return helper.SafeDivide(pcd, apcd, T(0)) * T(100)
 	})
 
 	return tsi

--- a/trend/vwma.go
+++ b/trend/vwma.go
@@ -51,11 +51,7 @@ func (v *Vwma[T]) ComputeWithContext(ctx context.Context, closing, volume <-chan
 	volumeSum := sum.ComputeWithContext(ctx, volumes[1])
 
 	return helper.OperateWithContext(ctx, priceVolumeSum, volumeSum, func(pv, vol T) T {
-		if vol == 0 {
-			return 0
-		}
-
-		return pv / vol
+		return helper.SafeDivide(pv, vol, T(0))
 	})
 }
 

--- a/volatility/acceleration_bands.go
+++ b/volatility/acceleration_bands.go
@@ -54,11 +54,7 @@ func (a *AccelerationBands[T]) ComputeWithContext(ctx context.Context, high, low
 	ks := helper.DuplicateWithContext(ctx, helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, highs[0], lows[0]),
 		helper.AddWithContext(ctx, highs[1], lows[1]),
 		func(diff, sum T) T {
-			if sum == 0 {
-				return 0
-			}
-
-			return diff / sum
+			return helper.SafeDivide(diff, sum, T(0))
 		},
 	),
 		2,

--- a/volatility/bollinger_band_width.go
+++ b/volatility/bollinger_band_width.go
@@ -45,11 +45,7 @@ func (b *BollingerBandWidth[T]) ComputeWithContext(ctx context.Context, c <-chan
 	upper, middle, lower := b.BollingerBands.ComputeWithContext(ctx, c)
 
 	return helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, upper, lower), middle, func(diff, middle T) T {
-		if middle == 0 {
-			return 0
-		}
-
-		return diff / middle
+		return helper.SafeDivide(diff, middle, T(0))
 	})
 }
 

--- a/volatility/percent_b.go
+++ b/volatility/percent_b.go
@@ -53,13 +53,8 @@ func (p *PercentB[T]) ComputeWithContext(ctx context.Context, closings <-chan T)
 	go helper.DrainWithContext(ctx, middleBands)
 
 	return helper.Operate3WithContext(ctx, upperBands, lowerBands, closingsSplice[1], func(upperBand, lowerBand, closing T) T {
-		denom := upperBand - lowerBand
-		if denom == 0 {
-			return 0.5
-		}
-
 		// %B = (Close - Lower Band) / (Upper Band - Lower Band)
-		return (closing - lowerBand) / denom
+		return helper.SafeDivide(closing-lowerBand, upperBand-lowerBand, T(0.5))
 	})
 }
 

--- a/volatility/po.go
+++ b/volatility/po.go
@@ -100,11 +100,7 @@ func (p *Po[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-
 	phMinusPl := helper.SubtractWithContext(ctx, ph, plSplice[1])
 
 	po := helper.Operate3WithContext(ctx, closingsSplice[1], plSplice[0], phMinusPl, func(closing, pl, denom T) T {
-		if denom == 0 {
-			return 50
-		}
-
-		return 100 * (closing - pl) / denom
+		return helper.SafeDivide(100*(closing-pl), denom, T(50))
 	})
 
 	return po

--- a/volatility/z_score.go
+++ b/volatility/z_score.go
@@ -61,11 +61,7 @@ func (z *ZScore[T]) ComputeWithContext(ctx context.Context, c <-chan T) <-chan T
 	priceChan := helper.SkipWithContext(ctx, cs[2], z.IdlePeriod())
 
 	return helper.OperateWithContext(ctx, helper.SubtractWithContext(ctx, priceChan, smaChan), stdChan, func(diff, std T) T {
-		if std == 0 {
-			return 0
-		}
-
-		return diff / std
+		return helper.SafeDivide(diff, std, T(0))
 	})
 }
 

--- a/volume/cmf.go
+++ b/volume/cmf.go
@@ -66,11 +66,7 @@ func (c *Cmf[T]) ComputeWithContext(ctx context.Context, highs, lows, closings, 
 	return helper.OperateWithContext(ctx, c.Sum.ComputeWithContext(ctx, mfvs),
 		c.Sum.ComputeWithContext(ctx, volumesSplice[1]),
 		func(mfvSum, volumeSum T) T {
-			if volumeSum == 0 {
-				return 0
-			}
-
-			return mfvSum / volumeSum
+			return helper.SafeDivide(mfvSum, volumeSum, T(0))
 		},
 	)
 }

--- a/volume/mfm.go
+++ b/volume/mfm.go
@@ -41,11 +41,7 @@ func NewMfm[T helper.Float]() *Mfm[T] {
 func (i *Mfm[T]) ComputeWithContext(ctx context.Context, highs, lows, closings <-chan T) <-chan T {
 	return helper.Operate3WithContext(ctx, highs, lows, closings, func(high, low, closing T) T {
 		denom := high - low
-		if denom == 0 {
-			return 0
-		}
-
-		return ((closing - low) - (high - closing)) / denom
+		return helper.SafeDivide((closing-low)-(high-closing), denom, T(0))
 	})
 }
 


### PR DESCRIPTION
## Summary

Earlier work independently added zero-denominator/NaN guards across ~17 indicators in `trend`, `momentum`, `volatility`, and `volume`, each shaped like:

```go
if denom == 0 {
    return fallback // 0, 50, or 0.5
}
return numerator / denom
```

This PR adds a single generic helper, `helper.SafeDivide[T Number](numerator, denominator, fallback T) T` (in `helper/safe_divide.go`, modeled on the existing scalar helper `helper.RoundDigit`), and refactors every matching call site to use it. Behavior is unchanged — same fallback values, same floating-point evaluation order — verified by the full existing test suite passing unmodified.

## Call sites refactored

Direct pattern (`SafeDivide(num, denom, fallback)` replaces the guard 1:1):

- `trend/kama.go` — Efficiency Ratio, fallback `0`
- `trend/bop.go` — BOP, fallback `0`
- `trend/vwma.go` — VWMA, fallback `0`
- `momentum/ibs.go` — Internal Bar Strength, fallback `0`
- `momentum/ultimate_oscillator.go` — per-period average, fallback `0.5`
- `volatility/bollinger_band_width.go` — fallback `0`
- `volatility/z_score.go` — fallback `0`
- `volatility/acceleration_bands.go` — fallback `0`
- `volatility/percent_b.go` — %B, fallback `0.5`
- `volume/mfm.go` — Money Flow Multiplier, fallback `0`
- `volume/cmf.go` — CMF, fallback `0`

Scaled pattern (original code applied a `* 100` or pre-multiplied the numerator by `100` around the guarded division; to keep the arithmetic byte-for-byte identical, the fallback is expressed in the same pre-scale units so the surrounding multiply reproduces the exact original float value):

- `trend/kdj.go` — RSV: `SafeDivide(num, denom, 0.5) * 100` (0.5 × 100 = 50, exact)
- `trend/slow_stochastic.go` — fastK: same transform
- `trend/stochastic.go` — %K: same transform
- `momentum/stochastic_oscillator.go` — fastK: same transform
- `trend/tsi.go` — `SafeDivide(pcd, apcd, 0) * 100` (fallback 0, scaling is a no-op)
- `trend/cfo.go` — `SafeDivide(num, price, 0) * 100` (same)
- `volatility/po.go` — original pre-multiplied the numerator (`100 * (closing - pl) / denom`), so here it's `SafeDivide(100*(closing-pl), denom, 50)` — fallback needs no rescaling since the original guard already returned the unscaled `50` literal

`helper.SafeDivide` is constrained to `helper.Number` (not `helper.Float`) specifically so that `trend/tsi.go`, whose `Tsi[T helper.Number]` is generic over integers too, can call it directly without widening or narrowing any existing type's constraint.

## Explicitly skipped (do not fit the pattern)

- `volume/vwap.go` — carries forward the last valid computed value instead of a constant fallback (per task instructions, left untouched).
- `trend/mcginley_dynamic.go` — same shape as Vwap: on a zero previous value it reseeds state and takes a completely different code path (not a single guarded return of a quotient), so it isn't a `SafeDivide` candidate.
- `momentum/rsi.go` — the guard condition is `averageGain == 0 && averageLoss == 0` (compound, two variables), not a single denominator check, so it doesn't fit `SafeDivide(numerator, denominator, fallback)`'s shape.
- `volatility/chop.go` — the guarded division feeds into `math.Log10(sum/diff)` rather than being returned directly as a quotient; the guard and the formula shape don't reduce to a plain `numerator/denominator`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no new files flagged; pre-existing unrelated formatting debt in unrelated `examples/`/`strategy/`/`backtest` test files, untouched by this PR)
- [x] `go test ./... -timeout 300s` — all packages pass unmodified, confirming no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv4stuAb6WuQ8rPZ4cupLp